### PR TITLE
Support more collection types + Able to set null value to nullable property + Value types will always be primitive

### DIFF
--- a/src/Mapster.Tests/WhenMappingCollections.cs
+++ b/src/Mapster.Tests/WhenMappingCollections.cs
@@ -56,7 +56,8 @@ namespace Mapster.Tests
         public Guid Id { get; set; }
         public string Name { get; set; }
         public Projects Project { get; set; }
-        public List<int> X { get; set; }
+
+        public HashSet<int> X { get; set; }
         public int[] Y { get; set; }
         public ICollection<Guid> Z { get; set; }
         public ArrayList Ids { get; set; }
@@ -107,7 +108,7 @@ namespace Mapster.Tests
                 dto.Project == person.Project);
 
             Assert.IsNotNull(dto.X);
-            Assert.IsTrue(dto.X.Count == 4 && dto.X[0] == 1 && dto.X[1] == 2 && dto.X[2] == 3 && dto.X[3] == 4);
+            Assert.IsTrue(dto.X.Count == 4 && dto.X.Contains(1) && dto.X.Contains(2) && dto.X.Contains(3) && dto.X.Contains(4));
 
             Assert.IsNotNull(dto.Y);
             Assert.IsTrue(dto.Y.Length == 3 && dto.Y[0] == 5 && dto.Y[1] == 6 && dto.Y[2] == 7);

--- a/src/Mapster.Tests/WhenMappingNullablePrimitives.cs
+++ b/src/Mapster.Tests/WhenMappingNullablePrimitives.cs
@@ -10,8 +10,6 @@ namespace Mapster.Tests
         [Test]
         public void Can_Map_From_Null_Source_To_Non_Nullable_Existing_Target()
         {
-            TypeAdapterConfig<NullablePrimitivesPoco, NonNullablePrimitivesDto>.NewConfig().IgnoreNullValues(true);
-
             var poco = new NullablePrimitivesPoco { Id = Guid.NewGuid(), Name = "TestName" };
 
             var dto = new NonNullablePrimitivesDto();

--- a/src/Mapster.Tests/WhenMappingNullablePrimitives.cs
+++ b/src/Mapster.Tests/WhenMappingNullablePrimitives.cs
@@ -10,6 +10,8 @@ namespace Mapster.Tests
         [Test]
         public void Can_Map_From_Null_Source_To_Non_Nullable_Existing_Target()
         {
+            TypeAdapterConfig<NullablePrimitivesPoco, NonNullablePrimitivesDto>.NewConfig().IgnoreNullValues(true);
+
             var poco = new NullablePrimitivesPoco { Id = Guid.NewGuid(), Name = "TestName" };
 
             var dto = new NonNullablePrimitivesDto();
@@ -48,6 +50,24 @@ namespace Mapster.Tests
             dto.Amount.ShouldBeNull();
         }
 
+        [Test]
+        public void Can_Map_From_Nullable_Source_To_Nullable_Existing_Target()
+        {
+            var poco = new NullablePrimitivesPoco { Id = Guid.NewGuid(), Name = "TestName" };
+
+            NullablePrimitivesPoco2 dto = new NullablePrimitivesPoco2
+            {
+                IsImport = true,
+                Amount = 1,
+            };
+
+            TypeAdapter.Adapt(poco, dto);
+
+            dto.Id.ShouldEqual(poco.Id);
+            dto.Name.ShouldEqual(poco.Name);
+            dto.IsImport.ShouldBeNull();
+            dto.Amount.ShouldBeNull();
+        }
 
         [Test]
         public void Can_Map_From_Nullable_Source_With_Values_To_Non_Nullable_Target()

--- a/src/Mapster.Tests/WhenMappingPrimitives.cs
+++ b/src/Mapster.Tests/WhenMappingPrimitives.cs
@@ -45,6 +45,21 @@ namespace Mapster.Tests
             testString.ShouldEqual(resultString);
         }
 
+        [Test]
+        public void ValueType_String_Object_Is_Always_Primitive()
+        {
+            var sourceDto = new PrimitivePoco
+            {
+                Id = "test",
+                Time = TimeSpan.FromHours(7),
+                Obj = new object(),
+            };
+            var targetDto = TypeAdapter.Adapt<PrimitivePoco, PrimitivePoco>(sourceDto);
+
+            targetDto.Id.ShouldEqual(sourceDto.Id);
+            targetDto.Time.ShouldEqual(sourceDto.Time);
+            targetDto.Obj.ShouldBeSameAs(sourceDto.Obj);
+        }
 
         public class TestA
         {
@@ -55,5 +70,13 @@ namespace Mapster.Tests
         {
             public Byte[] Bytes { get; set; }
         }
+        
+        public class PrimitivePoco
+        {
+            public string Id { get; set; }
+            public TimeSpan Time { get; set; }
+            public object Obj { get; set; }
+        }
+
     }
 }

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -123,7 +123,7 @@ namespace Mapster.Adapters
                     {
                         case 1: //Primitive
                             object primitiveValue = propertyModel.Getter.Invoke(source);
-                            if (primitiveValue == null)
+                            if (primitiveValue == null && ignoreNullValues)
                             {
                                 continue;
                             }

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -106,7 +106,9 @@ namespace Mapster.Adapters
             if (destination == null)
                 destination = DestinationFactory();
 
-            bool ignoreNullValues = isNew || (hasConfig && configSettings.IgnoreNullValues.HasValue && configSettings.IgnoreNullValues.Value);
+            bool ignoreNullValues = isNew 
+                || !typeof(TDestination).IsNullable()
+                || (hasConfig && configSettings.IgnoreNullValues.HasValue && configSettings.IgnoreNullValues.Value);
 
             PropertyModel<TSource, TDestination> propertyModel = null;
             try

--- a/src/Mapster/Adapters/CollectionAdapter.cs
+++ b/src/Mapster/Adapters/CollectionAdapter.cs
@@ -32,7 +32,6 @@ namespace Mapster.Adapters
             return Adapt(source, null, parameterIndexes);
         }
 
-        private static Func<TDestination> objectFactory; 
         public static object Adapt(TSource source, object destination, Dictionary<long, int> parameterIndexes)
         {
             if (source == null)
@@ -63,7 +62,7 @@ namespace Mapster.Adapters
             {
                 #region CopyToArray
 
-                byte i = 0;
+                int i = 0;
                 var adapterInvoker = _collectionAdapterModel.AdaptInvoker;
                 var array = destination == null ? new TDestinationElement[((ICollection)source).Count] : (TDestinationElement[])destination;
                 if (_collectionAdapterModel.IsPrimitive)
@@ -94,14 +93,23 @@ namespace Mapster.Adapters
                 #endregion
             }
 
-            if (!destinationType.IsInterface && typeof (ICollection<TDestinationElement>).IsAssignableFrom(destinationType))
+            var canInstantiate = !destinationType.IsInterface && typeof (ICollection<TDestinationElement>).IsAssignableFrom(destinationType);
+            if (canInstantiate || destinationType.IsAssignableFrom(typeof(List<TDestinationElement>)))
             {
                 #region CopyToList
 
                 var adapterInvoker = _collectionAdapterModel.AdaptInvoker;
-                if (objectFactory == null)
-                    objectFactory = FastObjectFactory.CreateObjectFactory<TDestination>();
-                var list = destination == null ? (ICollection<TDestinationElement>)objectFactory() : (ICollection<TDestinationElement>)destination;
+                ICollection<TDestinationElement> list;
+                if (destination == null)
+                {
+                    list = canInstantiate
+                        ? (ICollection<TDestinationElement>) ActivatorExtensions.CreateInstance(destinationType)
+                        : new List<TDestinationElement>();
+                }
+                else
+                {
+                    list = (ICollection<TDestinationElement>)destination;
+                }
                 if (_collectionAdapterModel.IsPrimitive)
                 {
                     bool hasInvoker = adapterInvoker != null;
@@ -128,44 +136,12 @@ namespace Mapster.Adapters
                 #endregion
             }
             
-            if (destinationType.IsGenericType)
-            {
-                #region CopyToList
-
-                var adapterInvoker = _collectionAdapterModel.AdaptInvoker;
-                var list = destination == null ? new List<TDestinationElement>() : (List<TDestinationElement>)destination;
-                if (_collectionAdapterModel.IsPrimitive)
-                {
-                    bool hasInvoker = adapterInvoker != null;
-                    foreach (var item in source)
-                    {
-                        if (item == null)
-                            list.Add(default(TDestinationElement));
-                        else if(hasInvoker)
-                            list.Add((TDestinationElement)adapterInvoker(null, new[] { item }));
-                        else
-                            list.Add((TDestinationElement)item);
-                    }
-                }
-                else
-                {
-                    foreach (var item in source)
-                    {
-                        list.Add((TDestinationElement)adapterInvoker(null, new[] { item, false, (hasMaxDepth ? ReflectionUtils.Clone(parameterIndexes) : parameterIndexes) }));
-                    }
-                }
-
-                return list;
-
-                #endregion
-            }
-            
-            if (destinationType == typeof(ArrayList))
+            if (!destinationType.IsInterface && typeof(IList).IsAssignableFrom(destinationType))
             {
                 #region CopyToArrayList
 
                 var adapterInvoker = _collectionAdapterModel.AdaptInvoker;
-                var array = destination == null ? new ArrayList() : (ArrayList)destination;
+                var array = destination == null ? (IList)ActivatorExtensions.CreateInstance(destinationType) : (IList)destination;
                 if (_collectionAdapterModel.IsPrimitive)
                 {
                     bool hasInvoker = adapterInvoker != null;

--- a/src/Mapster/Mapster.csproj
+++ b/src/Mapster/Mapster.csproj
@@ -37,6 +37,18 @@
     <DocumentationFile>bin\Release\Mapster.XML</DocumentationFile>
     <BaseAddress>1124073472</BaseAddress>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Cloud|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Cloud\</OutputPath>
+    <BaseAddress>1124073472</BaseAddress>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DocumentationFile>bin\Release\Mapster.XML</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Mapster/Mapster.csproj
+++ b/src/Mapster/Mapster.csproj
@@ -37,18 +37,6 @@
     <DocumentationFile>bin\Release\Mapster.XML</DocumentationFile>
     <BaseAddress>1124073472</BaseAddress>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Cloud|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Cloud\</OutputPath>
-    <BaseAddress>1124073472</BaseAddress>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Release\Mapster.XML</DocumentationFile>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Mapster/Models/PropertyModel.cs
+++ b/src/Mapster/Models/PropertyModel.cs
@@ -24,6 +24,6 @@ namespace Mapster.Models
 
         public string SetterPropertyName;
 
-       
+        public Type DestinationPropertyType;
     }
 }

--- a/src/Mapster/Utils/Activator.cs
+++ b/src/Mapster/Utils/Activator.cs
@@ -39,7 +39,7 @@ namespace Mapster.Utils
                     type.Name));
             }
 
-            var dynamicMethod = new DynamicMethod("DM$_" + type.Name, type, argTypes, type);
+            var dynamicMethod = new DynamicMethod("DM$_" + type.Name, type, argTypes);
             ILGenerator ilGen = dynamicMethod.GetILGenerator();
             for (int i = 0; i < argTypes.Length; i++)
             {

--- a/src/Mapster/Utils/FastObjectFactory.cs
+++ b/src/Mapster/Utils/FastObjectFactory.cs
@@ -21,7 +21,7 @@ namespace Mapster.Utils
             }
             else
             {
-                var dynMethod = new DynamicMethod("DM$OBJ_FACTORY_" + type.Name, type, null, type);
+                var dynMethod = new DynamicMethod("DM$OBJ_FACTORY_" + type.Name, type, null);
                 ILGenerator ilGen = dynMethod.GetILGenerator();
 
                 ilGen.Emit(OpCodes.Newobj, type.GetConstructor(Type.EmptyTypes));

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -19,6 +19,11 @@ namespace Mapster.Utils
             return type.IsGenericType && type.GetGenericTypeDefinition() == _nullableType;
         }
 
+        public static bool IsNonNullable(this Type type)
+        {
+            return type.IsValueType && !type.IsNullable();
+        }
+
         public static List<MemberInfo> GetPublicFieldsAndProperties(this Type type, bool allowNonPublicSetter = true, bool allowNoSetter = true)
         {
             var results = new List<MemberInfo>();

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -123,7 +123,11 @@ namespace Mapster.Utils
             {
                 return collectionType.GetGenericArguments()[0];
             }
-            return collectionType;
+            if (collectionType == typeof (object))
+            {
+                return collectionType;
+            }
+            return collectionType.BaseType.ExtractCollectionType();
         }
         
         public static FastInvokeHandler CreatePrimitiveConverter(this Type sourceType, Type destinationType)


### PR DESCRIPTION
Sorry for having more than one topic in single pull request. This is from my code base when I used Mapster for a while.

1. Support more collection types  
Current code base supports only array, List<>, generic interfaces such as IList<>, and ArrayList  
With this pull request, it will support all ICollection<> implementation, such as HashSet<>, ObservableCollection<>.  
And it also supports non-generic interfaces such as IList, ICollection, IEnumerable.
2. Able to set null value to nullable property.  
Current code base will never set null value to nullable property.  
I think Mapper should map all possible values to target.
3. Value types will always be primitive.  
All value types, such as TimeSpan, DateTimeOffset, even custom struct should always be primitive.  
Otherwise, it will error all cases when we map struct.  
This should reduce a lot of custom config added to primitive types.