### PR TITLE
Hotfix for EF create empty object on projection

### DIFF
--- a/src/Mapster.Tests/Classes/Product.cs
+++ b/src/Mapster.Tests/Classes/Product.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Mapster.Tests.Classes
 {
@@ -66,6 +67,7 @@ namespace Mapster.Tests.Classes
         public Guid Id { get; set; }
         public string Title { get; set; }
         public string CreatedUserName { get; set; }
+        public UserDTO ModifiedUser { get; set; }
         public List<OrderLineListDTO> OrderLines { get; set; }
     }
 

--- a/src/Mapster.Tests/WhenProjecting.cs
+++ b/src/Mapster.Tests/WhenProjecting.cs
@@ -72,6 +72,7 @@ namespace Mapster.Tests
                                     Id = Param_0.Id,
                                     Title = Param_0.Title,
                                     CreatedUserName = Param_0.CreatedUser.Name,
+                                    ModifiedUser = Param_0.ModifiedUser == null ? null : new UserDTO { Id = Param_0.ModifiedUser.Id, Email = Param_0.ModifiedUser.Email },
                                     OrderLines = (from Param_1 in Param_0.OrderLines
                                                   select new OrderLineListDTO
                                                   {

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -80,7 +80,7 @@ namespace Mapster.Adapters
 
             var exp = CreateInstantiationExpression(source, arg);
             var memberInit = exp as MemberInitExpression;
-            var newInstance = memberInit != null ? memberInit.NewExpression : (NewExpression)exp;
+            var newInstance = memberInit?.NewExpression ?? (NewExpression)exp;
             var properties = CreateAdapterModel(source, newInstance, arg);
 
             var lines = new List<MemberBinding>();
@@ -89,6 +89,23 @@ namespace Mapster.Adapters
             foreach (var property in properties)
             {
                 var getter = CreateAdaptExpression(property.Getter, property.Setter.Type, arg);
+
+                //special null property check for projection
+                //if we don't set null to property, EF will create empty object
+                //except collection type & complex type which cannot be null
+                if (arg.MapType == MapType.Projection 
+                    && property.Getter.Type != property.Setter.Type
+                    && !property.Getter.Type.IsCollection()
+                    && !property.Setter.Type.IsCollection()
+                    && property.Getter.Type.GetTypeInfo().GetCustomAttributes(true).Any(attr => attr.GetType().Name == "ComplexTypeAttribute")
+                    && (!property.Getter.Type.GetTypeInfo().IsValueType || property.Getter.Type.IsNullable()))
+                {
+                    var compareNull = Expression.Equal(property.Getter, Expression.Constant(null, property.Getter.Type));
+                    getter = Expression.Condition(
+                        compareNull,
+                        Expression.Constant(property.Setter.Type.GetDefault(), property.Setter.Type),
+                        getter);
+                }
                 var bind = Expression.Bind(property.SetterProperty, getter);
                 lines.Add(bind);
             }
@@ -134,7 +151,7 @@ namespace Mapster.Adapters
                 }
                 else
                 {
-                    if (FlattenMethod(source, destination, destinationMember, properties)) continue;
+                    if (arg.MapType != MapType.Projection && FlattenMethod(source, destination, destinationMember, properties)) continue;
 
                     if (FlattenClass(source, destination, destinationMember, properties, arg.MapType == MapType.Projection)) continue;
 

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -97,7 +97,7 @@ namespace Mapster.Adapters
                     && property.Getter.Type != property.Setter.Type
                     && !property.Getter.Type.IsCollection()
                     && !property.Setter.Type.IsCollection()
-                    && property.Getter.Type.GetTypeInfo().GetCustomAttributes(true).Any(attr => attr.GetType().Name == "ComplexTypeAttribute")
+                    && !property.Getter.Type.GetTypeInfo().GetCustomAttributes(true).Any(attr => attr.GetType().Name == "ComplexTypeAttribute")
                     && (!property.Getter.Type.GetTypeInfo().IsValueType || property.Getter.Type.IsNullable()))
                 {
                     var compareNull = Expression.Equal(property.Getter, Expression.Constant(null, property.Getter.Type));

--- a/src/Mapster/Adapters/CollectionAdapter.cs
+++ b/src/Mapster/Adapters/CollectionAdapter.cs
@@ -47,6 +47,9 @@ namespace Mapster.Adapters
                 var listType = typeof (List<>).MakeGenericType(destinationElementType);
                 if (arg.DestinationType.GetTypeInfo().IsAssignableFrom(listType.GetTypeInfo()))
                     return true;
+
+                throw new InvalidOperationException(
+                    $"{arg.DestinationType} is not supported for projection, please consider using List<>: TSource: {arg.SourceType} TDestination: {arg.DestinationType}");
             }
 
             if (arg.DestinationType == typeof (IEnumerable) || arg.DestinationType.IsGenericEnumerableType())

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -271,7 +271,12 @@ namespace Mapster
         {
             var tuple = new TypeTuple(sourceType, destinationType);
             if (context.Running.Contains(tuple))
+            {
+                if (mapType == MapType.Projection)
+                    throw new InvalidOperationException(
+                        $"Projection does not support circular reference: TSource: {sourceType} TDestination: {destinationType}");
                 return CreateInvokeExpression(sourceType, destinationType);
+            }
 
             context.Running.Add(tuple);
             try


### PR DESCRIPTION
if property is null, projection will create empty object rather than null value. This PR will check for null and return default value for projection.

This PR also included more descriptive error message for projection.