### PR TITLE
create ProjectToType and obsolete Project.To

### DIFF
--- a/src/Mapster.Tests/WhenProjecting.cs
+++ b/src/Mapster.Tests/WhenProjecting.cs
@@ -20,7 +20,7 @@ namespace Mapster.Tests
 
             var list = new List<TypeTestClassA>() { testA };
 
-            var bList = list.AsQueryable().Project().To<TypeTestClassB>().ToList();
+            var bList = list.AsQueryable().ProjectToType<TypeTestClassB>().ToList();
 
             Assert.IsNotNull(bList);
 
@@ -46,7 +46,7 @@ namespace Mapster.Tests
                 .Map(dest => dest.B, src => Convert.ToInt32(src.B))
                 .Map(dest => dest.C, src => src.C.ToString());
 
-            var bList = list.AsQueryable().Project().To<ConfigTestClassB>().ToList();
+            var bList = list.AsQueryable().ProjectToType<ConfigTestClassB>().ToList();
 
             Assert.IsNotNull(bList);
 
@@ -65,7 +65,7 @@ namespace Mapster.Tests
                 new Product {Id = Guid.NewGuid(), Title = "ProductB", CreatedUser = null, OrderLines = new List<OrderLine>()},
             };
 
-            var resultQuery = products.AsQueryable().Project().To<ProductDTO>();
+            var resultQuery = products.AsQueryable().ProjectToType<ProductDTO>();
             var expectedQuery = from Param_0 in products.AsQueryable()
                                 select new ProductDTO
                                 {

--- a/src/Mapster/QueryableExtensions.cs
+++ b/src/Mapster/QueryableExtensions.cs
@@ -1,13 +1,24 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
 using Mapster.Utils;
 
 namespace Mapster
 {
     public static class QueryableExtensions
     {
+        [Obsolete("Please use 'ProjectToType' method instead")]
         public static IProjectionExpression Project<TSource>(this IQueryable<TSource> source)
         {
             return new ProjectionExpression<TSource>(source);
         }
+
+        public static IQueryable<TDestination> ProjectToType<TDestination>(this IQueryable source, TypeAdapterConfig config = null)
+        {
+            config = config ?? TypeAdapterConfig.GlobalSettings;
+            var mockCall = config.GetProjectionCallExpression(source.ElementType, typeof(TDestination));
+            var sourceCall = Expression.Call(mockCall.Method, source.Expression, mockCall.Arguments[1]);
+            return source.Provider.CreateQuery<TDestination>(sourceCall);
+        } 
     }
 }


### PR DESCRIPTION
This is per #39.

I create `ProjectToType` to be used instead of `Project.To`. I don't know this is good name or not, naming thing is hard. We could rename to `ProjectTo` to match with AutoMapper. But in this case, VB call will be `ProjectTo(Of TDest)` instead of `ProjectToType(Of TDest)`.