### PR TITLE
Add IgnoreCaseSensitiveSetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,17 @@ In Mapster 2.0, you can even map when source and destination property types are 
         .Map(dest => dest.Gender,      //Genders.Male or Genders.Female
              src => src.GenderString); //"Male" or "Female"
 
+Mapster can also match properties with a different case sensitivity for a special configuration or on global level. 
+
+    TypeAdapterConfig<TSource, TDestination>
+        .NewConfig()
+        .Settings
+        .IgnoreCaseSensitiveNames = true;
+
+    TypeAdapterConfig
+        .GlobalSettings
+        .IgnoreCaseSensitiveNames = true;
+
 #####Merge object <a name="Merge"></a>
 By default, Mapster will map all properties, even source properties containing null values.
 You can copy only properties that have values by using `IgnoreNullValues` method.

--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="WhenRunningOnMultipleThreads.cs" />
     <Compile Include="WhenScanningForRegisters.cs" />
     <Compile Include="WhenUsingConverterFactory.cs" />
+    <Compile Include="WhenUsingIgnoreCaseSetting.cs" />
     <Compile Include="WhenUsingRuleBasedSetting.cs" />
     <Compile Include="WhenUsingNonDefaultConstructor.cs" />
   </ItemGroup>

--- a/src/Mapster.Tests/WhenUsingIgnoreCaseSetting.cs
+++ b/src/Mapster.Tests/WhenUsingIgnoreCaseSetting.cs
@@ -19,7 +19,10 @@ namespace Mapster.Tests
                 Value_A = 123,
                 VALUE_B = "abc"
             };
+
+            TypeAdapterConfig.GlobalSettings.IgnoreCaseSensitiveNames = false;
             TypeAdapterConfig<ClassA, ClassB>.NewConfig();
+
             var b = a.Adapt<ClassB>();
             Assert.AreEqual(a.Value_A, b.Value_A);
             Assert.AreNotEqual(a.VALUE_B, b.Value_B);
@@ -34,10 +37,46 @@ namespace Mapster.Tests
                 VALUE_B = "abc"
             };
 
+            TypeAdapterConfig.GlobalSettings.IgnoreCaseSensitiveNames = false;
             TypeAdapterConfig<ClassA, ClassB>.NewConfig().Settings.IgnoreCaseSensitiveNames = true;
+
             var b = a.Adapt<ClassB>();
             Assert.AreEqual(a.Value_A, b.Value_A);
             Assert.AreEqual(a.VALUE_B, b.Value_B);
+        }
+
+        [Test]
+        public void MapWithGlobalCaseSensitiveSetting()
+        {
+            var a = new ClassA()
+            {
+                Value_A = 123,
+                VALUE_B = "abc"
+            };
+
+            TypeAdapterConfig.GlobalSettings.IgnoreCaseSensitiveNames = true;
+            TypeAdapterConfig<ClassA, ClassB>.NewConfig();
+
+            var b = a.Adapt<ClassB>();
+            Assert.AreEqual(a.Value_A, b.Value_A);
+            Assert.AreEqual(a.VALUE_B, b.Value_B);
+        }
+
+        [Test]
+        public void MapWithOverwrittenGlobalSettings()
+        {
+            var a = new ClassA()
+            {
+                Value_A = 123,
+                VALUE_B = "abc"
+            };
+
+            TypeAdapterConfig.GlobalSettings.IgnoreCaseSensitiveNames = true;
+            TypeAdapterConfig<ClassA, ClassB>.NewConfig().Settings.IgnoreCaseSensitiveNames = false;
+
+            var b = a.Adapt<ClassB>();
+            Assert.AreEqual(a.Value_A, b.Value_A);
+            Assert.AreNotEqual(a.VALUE_B, b.Value_B);
         }
     }
 

--- a/src/Mapster.Tests/WhenUsingIgnoreCaseSetting.cs
+++ b/src/Mapster.Tests/WhenUsingIgnoreCaseSetting.cs
@@ -19,7 +19,7 @@ namespace Mapster.Tests
                 Value_A = 123,
                 VALUE_B = "abc"
             };
-
+            TypeAdapterConfig<ClassA, ClassB>.NewConfig();
             var b = a.Adapt<ClassB>();
             Assert.AreEqual(a.Value_A, b.Value_A);
             Assert.AreNotEqual(a.VALUE_B, b.Value_B);

--- a/src/Mapster.Tests/WhenUsingIgnoreCaseSetting.cs
+++ b/src/Mapster.Tests/WhenUsingIgnoreCaseSetting.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+
+namespace Mapster.Tests
+{
+    [TestFixture]
+    public class WhenUsingIgnoreCaseSetting
+    {
+        [Test]
+        public void MapWithCaseSensitiveAsDefault()
+        {
+            var a = new ClassA()
+            {
+                Value_A = 123,
+                VALUE_B = "abc"
+            };
+
+            var b = a.Adapt<ClassB>();
+            Assert.AreEqual(a.Value_A, b.Value_A);
+            Assert.AreNotEqual(a.VALUE_B, b.Value_B);
+        }
+
+        [Test]
+        public void MapWithCaseInSensitive()
+        {
+            var a = new ClassA()
+            {
+                Value_A = 123,
+                VALUE_B = "abc"
+            };
+
+            TypeAdapterConfig<ClassA, ClassB>.NewConfig().Settings.IgnoreCaseSensitiveNames = true;
+            var b = a.Adapt<ClassB>();
+            Assert.AreEqual(a.Value_A, b.Value_A);
+            Assert.AreEqual(a.VALUE_B, b.Value_B);
+        }
+    }
+
+    public class ClassA
+    {
+        public int Value_A { get; set; }
+        public string VALUE_B { get; set; }
+    }
+    public class ClassB
+    {
+        public int Value_A { get; set; }
+        public string Value_B { get; set; }
+    }
+}

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -31,7 +31,7 @@ namespace Mapster.Adapters
                 if (ProcessIgnores(arg.Settings, destinationMember)) continue;
                 if (ProcessCustomResolvers(source, destination, arg.Settings, destinationMember, properties)) continue;
 
-                var sourceMember = ReflectionUtils.GetMemberModel(sourceType, destinationMember.Name);
+                var sourceMember = ReflectionUtils.GetMemberModel(sourceType, destinationMember.Name, arg.Settings.IgnoreCaseSensitiveNames ?? false);
                 if (sourceMember != null)
                 {
                     var propertyModel = new MemberConverter

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -30,8 +30,8 @@ namespace Mapster.Adapters
 
                 if (ProcessIgnores(arg.Settings, destinationMember)) continue;
                 if (ProcessCustomResolvers(source, destination, arg.Settings, destinationMember, properties)) continue;
-
-                var sourceMember = ReflectionUtils.GetMemberModel(sourceType, destinationMember.Name, arg.Settings.IgnoreCaseSensitiveNames ?? false);
+                
+                var sourceMember = ReflectionUtils.GetMemberModel(sourceType, destinationMember.Name, arg.Settings.IgnoreCaseSensitiveNames ?? arg.Context.Config.IgnoreCaseSensitiveNames);
                 if (sourceMember != null)
                 {
                     var propertyModel = new MemberConverter

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -27,6 +27,7 @@ namespace Mapster
         public bool RequireDestinationMemberSource;
         public bool RequireExplicitMapping;
         public bool AllowImplicitDestinationInheritance;
+        public bool IgnoreCaseSensitiveNames;
 
         public readonly List<TypeAdapterRule> Rules;
         public readonly TypeAdapterSetter Default;

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -23,6 +23,7 @@ namespace Mapster
         public bool? PreserveReference;
         public bool? ShallowCopyForSameType;
         public bool? IgnoreNullValues;
+        public bool? IgnoreCaseSensitiveNames;
         public bool? NoInherit;
         public Type DestinationType;
 
@@ -44,6 +45,9 @@ namespace Mapster
                     this.ShallowCopyForSameType = other.ShallowCopyForSameType;
                 if (this.IgnoreNullValues == null)
                     this.IgnoreNullValues = other.IgnoreNullValues;
+                if (this.IgnoreCaseSensitiveNames == null)
+                    this.IgnoreCaseSensitiveNames = other.IgnoreCaseSensitiveNames;
+
 
                 this.IgnoreMembers.UnionWith(other.IgnoreMembers);
                 this.IgnoreAttributes.UnionWith(other.IgnoreAttributes);

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -41,13 +41,14 @@ namespace Mapster
             return results;
         }
 
-        public static IMemberModel GetMemberModel(Type type, string name)
+        public static IMemberModel GetMemberModel(Type type, string name, bool ignoreCaseSensitiveNames)
         {
-            var prop = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            var nameComparsonOption = ignoreCaseSensitiveNames ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            var prop = type.GetProperties(BindingFlags.Public | BindingFlags.Instance).FirstOrDefault(p=>p.Name.Equals(name, nameComparsonOption));
             if (prop != null)
                 return new PropertyModel(prop);
 
-            var field = type.GetField(name, BindingFlags.Public | BindingFlags.Instance);
+            var field = type.GetFields(BindingFlags.Public | BindingFlags.Instance).FirstOrDefault(f=>f.Name.Equals(name, nameComparsonOption));
             if (field != null)
                 return new FieldModel(field);
 


### PR DESCRIPTION
I have implemented the feature to ignore the CaseSensitiv naming of class members.
https://github.com/eswann/Mapster/issues/49