### PR TITLE
Passing Runtime value

### DIFF
--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="WhenMappingRecordTypes.cs" />
     <Compile Include="WhenMappingIgnoreNullValues.cs" />
     <Compile Include="WhenMappingWithExtensionMethods.cs" />
+    <Compile Include="WhenPassingRuntimeValue.cs" />
     <Compile Include="WhenPreserveReferences.cs" />
     <Compile Include="WhenAddingCustomMappings.cs" />
     <Compile Include="WhenHandlingUnmappedMembers.cs" />

--- a/src/Mapster.Tests/WhenPassingRuntimeValue.cs
+++ b/src/Mapster.Tests/WhenPassingRuntimeValue.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using NUnit.Framework;
+using Should;
+
+namespace Mapster.Tests
+{
+    public class WhenPassingRuntimeValue
+    {
+        [Test]
+        public void Passing_Runtime_Value()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .Map(dest => dest.CreatedBy,
+                    src => MapContext.Current.Parameters["user"]);
+
+            var poco = new SimplePoco
+            {
+                Id = Guid.NewGuid(),
+                Name = "test",
+            };
+            var dto = poco.BuildAdapter()
+                .AddParameters("user", this.User)
+                .AdaptToType<SimpleDto>();
+
+            dto.CreatedBy.ShouldEqual(this.User);
+        }
+
+        private string User { get; } = Guid.NewGuid().ToString("N");
+
+        public class SimplePoco
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        public class SimpleDto
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+            public string CreatedBy { get; set; }
+        }
+
+    }
+}

--- a/src/Mapster/Adapter.cs
+++ b/src/Mapster/Adapter.cs
@@ -4,6 +4,7 @@ namespace Mapster
 {
     public interface IAdapter
     {
+        TypeAdapter<TSource> BuildAdapter<TSource>(TSource source);
         TDestination Adapt<TDestination>(object source);
         TDestination Adapt<TSource, TDestination>(TSource source);
         TDestination Adapt<TSource, TDestination>(TSource source, TDestination destination);
@@ -20,6 +21,11 @@ namespace Mapster
         public Adapter(TypeAdapterConfig config)
         {
             _config = config;
+        }
+
+        public TypeAdapter<TSource> BuildAdapter<TSource>(TSource source)
+        {
+            return new TypeAdapter<TSource>(source).UseConfig(_config);
         }
 
         public TDestination Adapt<TDestination>(object source)

--- a/src/Mapster/MapContext.cs
+++ b/src/Mapster/MapContext.cs
@@ -42,6 +42,12 @@ namespace Mapster
         {
             get { return _references ?? (_references = new Dictionary<object, object>(ReferenceComparer.Default)); }
         }
+
+        private Dictionary<string, object> _parameters;
+        public Dictionary<string, object> Parameters
+        {
+            get { return _parameters ?? (_parameters = new Dictionary<string, object>(ReferenceComparer.Default)); }
+        }
     }
     internal class MapContextScope : IDisposable
     {


### PR DESCRIPTION
Fix #48 

(Please merge #53 first before reviewing this PR.)

This PR includes
1. Passing run-time values to config
2. New builder pattern which allow us to pass run-time config to Adapt method.

**Example**

On configuration, we can receive run-time value by `MapContext.Current.Parameters`.

```
TypeAdapterConfig<Poco, Dto>.NewConfig()
                            .Map(dest => dest.CreatedBy,
                                 src => MapContext.Current.Parameters["user"]);
```

To pass run-time value.

```
var dto = poco.BuildAdapter()
              .AddParameters("user", this.User.Identity.Name)
              .AdaptToType<SimpleDto>();
```

