### PR TITLE
Flexible name matching

### DIFF
--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="WhenMappingRecordTypes.cs" />
     <Compile Include="WhenMappingIgnoreNullValues.cs" />
     <Compile Include="WhenMappingWithExtensionMethods.cs" />
+    <Compile Include="WhenMappingWithFlexibleName.cs" />
     <Compile Include="WhenPerformingAfterMapping.cs" />
     <Compile Include="WhenPassingRuntimeValue.cs" />
     <Compile Include="WhenPreserveReferences.cs" />

--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -68,7 +68,7 @@
     <Compile Include="Classes\TypeTestClass.cs" />
     <Compile Include="WhenCloningConfig.cs" />
     <Compile Include="WhenCreatingConfigInstance.cs" />
-    <Compile Include="WhenMappingObjectToDictionary.cs" />
+    <Compile Include="WhenMappingWithDictionary.cs" />
     <Compile Include="WhenMappingRecordTypes.cs" />
     <Compile Include="WhenMappingIgnoreNullValues.cs" />
     <Compile Include="WhenMappingWithExtensionMethods.cs" />

--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Classes\TypeTestClass.cs" />
     <Compile Include="WhenCloningConfig.cs" />
     <Compile Include="WhenCreatingConfigInstance.cs" />
+    <Compile Include="WhenMappingObjectToDictionary.cs" />
     <Compile Include="WhenMappingRecordTypes.cs" />
     <Compile Include="WhenMappingIgnoreNullValues.cs" />
     <Compile Include="WhenMappingWithExtensionMethods.cs" />

--- a/src/Mapster.Tests/WhenMappingObjectToDictionary.cs
+++ b/src/Mapster.Tests/WhenMappingObjectToDictionary.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Should;
+
+namespace Mapster.Tests
+{
+    public class WhenMappingObjectToDictionary
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            TypeAdapterConfig.GlobalSettings.Clear();
+        }
+
+        [Test]
+        public void Object_To_Dictionary()
+        {
+            var poco = new SimplePoco
+            {
+                Id = Guid.NewGuid(),
+                Name = "test",
+            };
+
+            var dict = TypeAdapter.Adapt<Dictionary<string, object>>(poco);
+
+            dict.Count.ShouldEqual(2);
+            dict["Id"].ShouldEqual(poco.Id);
+            dict["Name"].ShouldEqual(poco.Name);
+        }
+
+        [Test]
+        public void Object_To_Dictionary_Ignore_Null_Values()
+        {
+            TypeAdapterConfig<SimplePoco, Dictionary<string, object>>.NewConfig()
+                .IgnoreNullValues(true);
+
+            var poco = new SimplePoco
+            {
+                Id = Guid.NewGuid(),
+                Name = null,
+            };
+
+            var dict = TypeAdapter.Adapt<Dictionary<string, object>>(poco);
+
+            dict.Count.ShouldEqual(1);
+            dict["Id"].ShouldEqual(poco.Id);
+        }
+
+        public class SimplePoco
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/src/Mapster.Tests/WhenMappingWithDictionary.cs
+++ b/src/Mapster.Tests/WhenMappingWithDictionary.cs
@@ -5,7 +5,7 @@ using Should;
 
 namespace Mapster.Tests
 {
-    public class WhenMappingObjectToDictionary
+    public class WhenMappingWithDictionary
     {
         [TearDown]
         public void TearDown()
@@ -45,6 +45,20 @@ namespace Mapster.Tests
 
             dict.Count.ShouldEqual(1);
             dict["Id"].ShouldEqual(poco.Id);
+        }
+
+        [Test]
+        public void Dictionary_To_Object()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                ["Id"] = Guid.NewGuid(),
+                ["Foo"] = "test",
+            };
+
+            var poco = TypeAdapter.Adapt<SimplePoco>(dict);
+            poco.Id.ShouldEqual(dict["Id"]);
+            poco.Name.ShouldBeNull();
         }
 
         public class SimplePoco

--- a/src/Mapster.Tests/WhenMappingWithFlexibleName.cs
+++ b/src/Mapster.Tests/WhenMappingWithFlexibleName.cs
@@ -1,0 +1,83 @@
+﻿using NUnit.Framework;
+using Should;
+
+namespace Mapster.Tests
+{
+    [TestFixture]
+    public class WhenMappingWithFlexibleName
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            TypeAdapterConfig.GlobalSettings.Clear();
+        }
+
+        [Test]
+        public void Not_Set_Match_Only_Exact_Name()
+        {
+            var mix = new MixName
+            {
+                PascalCase = "A",
+                camelCase = "B",
+                __under__SCORE__ = "C",
+                lower_case = "D",
+                UPPER_CASE = "E",
+                MIX_UnderScore = "F",
+            };
+
+            var simple = TypeAdapter.Adapt<SimpleName>(mix);
+
+            simple.PascalCase.ShouldEqual(mix.PascalCase);
+            simple.CamelCase.ShouldBeNull();
+            simple.UnderScore.ShouldBeNull();
+            simple.LowerCase.ShouldBeNull();
+            simple.UpperCase.ShouldBeNull();
+            simple.MixUnder_SCORE.ShouldBeNull();
+        }
+
+        [Test]
+        public void Map_Flexible_Name()
+        {
+            TypeAdapterConfig<MixName, SimpleName>.NewConfig().NameMatchingStrategy(NameMatchingStrategy.Flexible);
+
+            var mix = new MixName
+            {
+                PascalCase = "A",
+                camelCase = "B",
+                __under__SCORE__ = "C",
+                lower_case = "D",
+                UPPER_CASE = "E",
+                MIX_UnderScore = "F",
+            };
+
+            var simple = TypeAdapter.Adapt<SimpleName>(mix);
+
+            simple.PascalCase.ShouldEqual(mix.PascalCase);
+            simple.CamelCase.ShouldEqual(mix.camelCase);
+            simple.UnderScore.ShouldEqual(mix.__under__SCORE__);
+            simple.LowerCase.ShouldEqual(mix.lower_case);
+            simple.UpperCase.ShouldEqual(mix.UPPER_CASE);
+            simple.MixUnder_SCORE.ShouldEqual(mix.MIX_UnderScore);
+        }
+
+        public class MixName
+        {
+            public string PascalCase { get; set; }
+            public string camelCase { get; set; }
+            public string __under__SCORE__ { get; set; }
+            public string lower_case { get; set; }
+            public string UPPER_CASE { get; set; }
+            public string MIX_UnderScore { get; set; }
+        }
+
+        public class SimpleName
+        {
+            public string PascalCase { get; set; }
+            public string CamelCase { get; set; }
+            public string UnderScore { get; set; }
+            public string LowerCase { get; set; }
+            public string UpperCase { get; set; }
+            public string MixUnder_SCORE { get; set; }
+        }
+    }
+}

--- a/src/Mapster.Tests/WhenMappingWithFlexibleName.cs
+++ b/src/Mapster.Tests/WhenMappingWithFlexibleName.cs
@@ -60,6 +60,19 @@ namespace Mapster.Tests
             simple.MixUnder_SCORE.ShouldEqual(mix.MIX_UnderScore);
         }
 
+        [Test]
+        public void Test_Name()
+        {
+            NameMatchingStrategy.ToPascalCase("PascalCase").ShouldEqual("PascalCase");
+            NameMatchingStrategy.ToPascalCase("camelCase").ShouldEqual("CamelCase");
+            NameMatchingStrategy.ToPascalCase("lower_case").ShouldEqual("LowerCase");
+            NameMatchingStrategy.ToPascalCase("UPPER_CASE").ShouldEqual("UpperCase");
+            NameMatchingStrategy.ToPascalCase("IPAddress").ShouldEqual("IpAddress");
+            NameMatchingStrategy.ToPascalCase("ItemID").ShouldEqual("ItemId");
+            NameMatchingStrategy.ToPascalCase("__under__SCORE__").ShouldEqual("UnderScore");
+            NameMatchingStrategy.ToPascalCase("__MixMIXMix_mix").ShouldEqual("MixMixMixMix");
+        }
+
         public class MixName
         {
             public string PascalCase { get; set; }

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -10,6 +10,7 @@ namespace Mapster.Adapters
     public abstract class BaseAdapter
     {
         protected virtual int Score => 0;
+        protected virtual bool CheckExplicitMapping => true;
 
         public virtual int? Priority(Type sourceType, Type destinationType, MapType mapType)
         {
@@ -73,6 +74,14 @@ namespace Mapster.Adapters
 
         protected virtual Expression CreateExpressionBody(Expression source, Expression destination, CompileArgument arg)
         {
+            if (this.CheckExplicitMapping
+                && arg.Context.Config.RequireExplicitMapping
+                && !arg.Context.Config.RuleMap.ContainsKey(new TypeTuple(arg.SourceType, arg.DestinationType)))
+            {
+                throw new InvalidOperationException(
+                    $"Implicit mapping is not allowed (check GlobalSettings.RequireExplicitMapping) and no configuration exists for the following mapping: TSource: {arg.SourceType} TDestination: {arg.DestinationType}");
+            }
+
             return CanInline(source, destination, arg) 
                 ? CreateInlineExpressionBody(source, arg).To(arg.DestinationType) 
                 : CreateBlockExpressionBody(source, destination, arg);

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using Mapster.Models;
-using Mapster.Utils;
 
 namespace Mapster.Adapters
 {
@@ -16,7 +14,6 @@ namespace Mapster.Adapters
 
         protected ClassMapping CreateClassConverter(Expression source, Expression destination, CompileArgument arg)
         {
-            Type sourceType = source.Type;
             var classModel = GetClassModel(arg.DestinationType);
             var destinationMembers = classModel.Members;
 
@@ -24,48 +21,38 @@ namespace Mapster.Adapters
 
             var properties = new List<MemberMapping>();
 
-            for (int i = 0; i < destinationMembers.Count; i++)
+            foreach (var destinationMember in destinationMembers)
             {
-                var destinationMember = destinationMembers[i];
-
                 if (ProcessIgnores(arg.Settings, destinationMember)) continue;
-                if (ProcessCustomResolvers(source, destination, arg.Settings, destinationMember, properties)) continue;
 
-                var sourceMember = ReflectionUtils.GetMemberModel(sourceType, destinationMember.Name);
-                if (sourceMember != null)
+                var member = destinationMember;
+                var getter = arg.Settings.ValueAccessingStrategies
+                    .Select(fn => fn(source, member, arg))
+                    .FirstOrDefault(result => result != null);
+
+                if (getter != null)
                 {
                     var propertyModel = new MemberMapping
                     {
-                        ConvertType = 1,
-                        Getter = sourceMember.GetExpression(source),
+                        Getter = getter,
                         Setter = destinationMember.GetExpression(destination),
                         SetterInfo = destinationMember.Info,
                     };
                     properties.Add(propertyModel);
                 }
-                else
+                else if (classModel.ConstructorInfo != null)
                 {
-                    if (arg.MapType != MapType.Projection && FlattenMethod(source, destination, destinationMember, properties)) continue;
-
-                    if (FlattenClass(source, destination, destinationMember, properties, arg.MapType == MapType.Projection)) continue;
-
-                    if (classModel.ConstructorInfo != null)
+                    var propertyModel = new MemberMapping
                     {
-                        var propertyModel = new MemberMapping
-                        {
-                            ConvertType = 0,
-                            Getter = null,
-                            Setter = destinationMember.GetExpression(destination),
-                            SetterInfo = destinationMember.Info,
-                        };
-                        properties.Add(propertyModel);
-                        continue;
-                    }
-
-                    if (destinationMember.HasSetter)
-                    {
-                        unmappedDestinationMembers.Add(destinationMember.Name);
-                    }
+                        Getter = null,
+                        Setter = destinationMember.GetExpression(destination),
+                        SetterInfo = destinationMember.Info,
+                    };
+                    properties.Add(propertyModel);
+                }
+                else if (destinationMember.SetterModifier != AccessModifier.None)
+                {
+                    unmappedDestinationMembers.Add(destinationMember.Name);
                 }
             }
 
@@ -79,102 +66,6 @@ namespace Mapster.Adapters
                 ConstructorInfo = classModel.ConstructorInfo,
                 Members = properties,
             };
-        }
-
-        private static bool FlattenClass(
-            Expression source,
-            Expression destination,
-            IMemberModel destinationMember,
-            List<MemberMapping> properties,
-            bool isProjection)
-        {
-            var getter = ReflectionUtils.GetDeepFlattening(source, destinationMember.Name, isProjection);
-            if (getter != null)
-            {
-                var propertyModel = new MemberMapping
-                {
-                    ConvertType = 3,
-                    Getter = getter,
-                    Setter = destinationMember.GetExpression(destination),
-                    SetterInfo = destinationMember.Info,
-                };
-                properties.Add(propertyModel);
-
-                return true;
-            }
-            return false;
-        }
-
-        private static bool FlattenMethod(
-            Expression source,
-            Expression destination,
-            IMemberModel destinationMember,
-            List<MemberMapping> properties)
-        {
-            var getMethod = source.Type.GetMethod(string.Concat("Get", destinationMember.Name), BindingFlags.Public | BindingFlags.Instance);
-            if (getMethod != null)
-            {
-                var propertyModel = new MemberMapping
-                {
-                    ConvertType = 2,
-                    Getter = Expression.Call(source, getMethod),
-                    Setter = destinationMember.GetExpression(destination),
-                    SetterInfo = destinationMember.Info,
-                };
-
-                properties.Add(propertyModel);
-
-                return true;
-            }
-            return false;
-        }
-
-        private static bool ProcessCustomResolvers(
-            Expression source,
-            Expression destination,
-            TypeAdapterSettings config,
-            IMemberModel destinationMember,
-            List<MemberMapping> properties)
-        {
-            bool isAdded = false;
-            var resolvers = config.Resolvers;
-            if (resolvers != null && resolvers.Count > 0)
-            {
-                MemberMapping memberConverter = null;
-                LambdaExpression lastCondition = null;
-                for (int j = 0; j < resolvers.Count; j++)
-                {
-                    var resolver = resolvers[j];
-                    if (destinationMember.Name.Equals(resolver.MemberName))
-                    {
-                        if (memberConverter == null)
-                        {
-                            memberConverter = new MemberMapping
-                            {
-                                ConvertType = 5,
-                                Setter = destinationMember.GetExpression(destination),
-                                SetterInfo = destinationMember.Info,
-                            };
-                            isAdded = true;
-                        }
-
-                        Expression invoke = resolver.Invoker.Apply(source);
-                        memberConverter.Getter = lastCondition != null
-                            ? Expression.Condition(lastCondition.Apply(source), memberConverter.Getter, invoke)
-                            : invoke;
-                        lastCondition = resolver.Condition;
-                        if (resolver.Condition == null)
-                            break;
-                    }
-                }
-                if (memberConverter != null)
-                {
-                    if (lastCondition != null)
-                        memberConverter.Getter = Expression.Condition(lastCondition.Apply(source), memberConverter.Getter, Expression.Constant(memberConverter.Getter.Type.GetDefault(), memberConverter.Getter.Type));
-                    properties.Add(memberConverter);
-                }
-            }
-            return isAdded;
         }
 
         private static bool ProcessIgnores(TypeAdapterSettings config, IMemberModel destinationMember)

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -38,18 +38,6 @@ namespace Mapster.Adapters
             return true;
         }
 
-        protected override Expression CreateExpressionBody(Expression source, Expression destination, CompileArgument arg)
-        {
-            if (arg.Context.Config.RequireExplicitMapping 
-                && !arg.Context.Config.RuleMap.ContainsKey(new TypeTuple(arg.SourceType, arg.DestinationType)))
-            {
-                throw new InvalidOperationException(
-                    $"Implicit mapping is not allowed (check GlobalSettings.RequireExplicitMapping) and no configuration exists for the following mapping: TSource: {arg.SourceType} TDestination: {arg.DestinationType}");
-            }
-
-            return base.CreateExpressionBody(source, destination, arg);
-        }
-
         protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)
         {
             //### !IgnoreNullValues

--- a/src/Mapster/Adapters/CollectionAdapter.cs
+++ b/src/Mapster/Adapters/CollectionAdapter.cs
@@ -11,6 +11,7 @@ namespace Mapster.Adapters
     internal class CollectionAdapter : BaseAdapter
     {
         protected override int Score => -125;
+        protected override bool CheckExplicitMapping => false;
 
         protected override bool CanMap(Type sourceType, Type destinationType, MapType mapType)
         {
@@ -97,7 +98,7 @@ namespace Mapster.Adapters
             else
             {
                 var destinationElementType = destination.Type.ExtractCollectionType();
-                var listType = destination.Type.IsGenericEnumerableType() || destination.Type.GetInterfaces().Any(ReflectionUtils.IsGenericEnumerableType)
+                var listType = destination.Type.GetGenericEnumerableType() != null
                     ? typeof(ICollection<>).MakeGenericType(destinationElementType)
                     : typeof(IList);
                 var tmp = Expression.Variable(listType);

--- a/src/Mapster/Adapters/DictionaryAdapter.cs
+++ b/src/Mapster/Adapters/DictionaryAdapter.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Mapster.Adapters
+{
+    internal class DictionaryAdapter : BaseAdapter
+    {
+        protected override int Score => -149;
+
+        protected override bool CanMap(Type sourceType, Type destinationType, MapType mapType)
+        {
+            if (sourceType == typeof (string) || sourceType == typeof (object))
+                return false;
+
+            return GetDictionaryType(destinationType) != null;
+        }
+
+        private static Type GetDictionaryType(Type destinationType)
+        {
+            return destinationType.GetInterface(type => type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+        }
+
+        protected override bool CanInline(Expression source, Expression destination, CompileArgument arg)
+        {
+            if (!base.CanInline(source, destination, arg))
+                return false;
+            if (arg.MapType != MapType.Projection &&
+                arg.Settings.IgnoreNullValues == true)
+                return false;
+            return true;
+        }
+
+        protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)
+        {
+            //### !IgnoreNullValues
+            //dict.Add("Prop1", convert(src.Prop1));
+            //dict.Add("Prop2", convert(src.Prop2));
+
+            //### IgnoreNullValues
+            //if (src.Prop1 != null)
+            //  dict.Add("Prop1", convert(src.Prop1));
+            //if (src.Prop2 != null)
+            //  dict.Add("Prop2", convert(src.Prop2));
+
+            var dictType = GetDictionaryType(destination.Type);
+            var dictTypeArgs = dictType.GetGenericArguments();
+            var keyType = dictTypeArgs[0];
+            var valueType = dictTypeArgs[1];
+            var indexer = dictType.GetProperties().First(item => item.GetIndexParameters().Length > 0);
+            var lines = new List<Expression>();
+
+            var dict = Expression.Variable(dictType);
+            lines.Add(Expression.Assign(dict, destination));
+
+            var properties = source.Type.GetPublicFieldsAndProperties();
+            foreach (var property in properties)
+            {
+                var getter = property.GetExpression(source);
+                var value = CreateAdaptExpression(getter, valueType, arg);
+
+                Expression key = Expression.Constant(property.Name);
+                key = CreateAdaptExpression(key, keyType, arg);
+
+                Expression itemSet = Expression.Assign(Expression.Property(dict, indexer, key), value);
+                if (arg.Settings.IgnoreNullValues == true && (!getter.Type.GetTypeInfo().IsValueType || getter.Type.IsNullable()))
+                {
+                    var condition = Expression.NotEqual(getter, Expression.Constant(null, getter.Type));
+                    itemSet = Expression.IfThen(condition, itemSet);
+                }
+                lines.Add(itemSet);
+            }
+
+            return Expression.Block(new[] {dict}, lines);
+        }
+
+        protected override Expression CreateInlineExpression(Expression source, CompileArgument arg)
+        {
+            //new TDestination {
+            //  { "Prop1", convert(src.Prop1) },
+            //  { "Prop2", convert(src.Prop2) },
+            //}
+
+            var exp = CreateInstantiationExpression(source, arg);
+            var listInit = exp as ListInitExpression;
+            var newInstance = listInit?.NewExpression ?? (NewExpression)exp;
+
+            var dictType = GetDictionaryType(arg.DestinationType);
+            var dictTypeArgs = dictType.GetGenericArguments();
+            var keyType = dictTypeArgs[0];
+            var valueType = dictTypeArgs[1];
+            var add = dictType.GetMethod("Add", new[] { keyType, valueType });
+            var lines = new List<ElementInit>();
+            if (listInit != null)
+                lines.AddRange(listInit.Initializers);
+
+            var properties = source.Type.GetPublicFieldsAndProperties();
+            foreach (var property in properties)
+            {
+                var getter = property.GetExpression(source);
+                var value = CreateAdaptExpression(getter, valueType, arg);
+
+                Expression key = Expression.Constant(property.Name);
+                key = CreateAdaptExpression(key, keyType, arg);
+
+                var itemInit = Expression.ElementInit(add, key, value);
+                lines.Add(itemInit);
+            }
+
+            return Expression.ListInit(newInstance, lines);
+        }
+    }
+}

--- a/src/Mapster/Adapters/PrimitiveAdapter.cs
+++ b/src/Mapster/Adapters/PrimitiveAdapter.cs
@@ -7,6 +7,7 @@ namespace Mapster.Adapters
     internal class PrimitiveAdapter : BaseAdapter
     {
         protected override int Score => -200;
+        protected override bool CheckExplicitMapping => false;
 
         protected override bool CanMap(Type sourceType, Type destinationType, MapType mapType)
         {

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -23,18 +23,6 @@ namespace Mapster.Adapters
             return true;
         }
 
-        protected override Expression CreateExpressionBody(Expression source, Expression destination, CompileArgument arg)
-        {
-            if (arg.Context.Config.RequireExplicitMapping
-                && !arg.Context.Config.RuleMap.ContainsKey(new TypeTuple(arg.SourceType, arg.DestinationType)))
-            {
-                throw new InvalidOperationException(
-                    $"Implicit mapping is not allowed (check GlobalSettings.RequireExplicitMapping) and no configuration exists for the following mapping: TSource: {arg.SourceType} TDestination: {arg.DestinationType}");
-            }
-
-            return base.CreateExpressionBody(source, destination, arg);
-        }
-
         protected override Expression CreateInstantiationExpression(Expression source, CompileArgument arg)
         {
             //new TDestination(src.Prop1, src.Prop2)

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -81,7 +81,7 @@ namespace Mapster.Adapters
                     select new ClassModel
                     {
                         ConstructorInfo = ctor,
-                        Members = ps.Select(ReflectionUtils.CreateModel).ToList()
+                        Members = ps.Select(ReflectionUtils.CreateModel)
                     }).First();
         }
 

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -73,10 +73,10 @@ namespace Mapster.Adapters
         protected override ClassModel GetClassModel(Type destinationType)
         {
             var props = destinationType.GetPublicFieldsAndProperties();
-            var names = props.Select(p => p.Name).ToHashSet();
+            var names = props.Select(p => p.Name.ToPascalCase()).ToHashSet();
             return (from ctor in destinationType.GetConstructors()
                     let ps = ctor.GetParameters()
-                    where ps.Length > 0 && names.IsSupersetOf(ps.Select(p => p.Name.ToProperCase()))
+                    where ps.Length > 0 && names.IsSupersetOf(ps.Select(p => p.Name.ToPascalCase()))
                     orderby ps.Length descending
                     select new ClassModel
                     {

--- a/src/Mapster/Mapster.csproj
+++ b/src/Mapster/Mapster.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Adapters\RecordTypeAdapter.cs" />
     <Compile Include="IRegister.cs" />
     <Compile Include="MapContext.cs" />
+    <Compile Include="NameMatchingStrategy.cs" />
     <Compile Include="ValueAccessingStrategy.cs" />
     <Compile Include="Models\AccessModifier.cs" />
     <Compile Include="Utils\BlockExpressionDetector.cs" />

--- a/src/Mapster/Mapster.csproj
+++ b/src/Mapster/Mapster.csproj
@@ -58,6 +58,8 @@
     <Compile Include="Adapters\RecordTypeAdapter.cs" />
     <Compile Include="IRegister.cs" />
     <Compile Include="MapContext.cs" />
+    <Compile Include="ValueAccessingStrategy.cs" />
+    <Compile Include="Models\AccessModifier.cs" />
     <Compile Include="Utils\BlockExpressionDetector.cs" />
     <Compile Include="Models\ClassMapping.cs" />
     <Compile Include="Models\ClassModel.cs" />

--- a/src/Mapster/Mapster.csproj
+++ b/src/Mapster/Mapster.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Adapter.cs" />
     <Compile Include="Adapters\BaseAdapter.cs" />
     <Compile Include="Adapters\BaseClassAdapter.cs" />
+    <Compile Include="Adapters\DictionaryAdapter.cs" />
     <Compile Include="Adapters\RecordTypeAdapter.cs" />
     <Compile Include="IRegister.cs" />
     <Compile Include="MapContext.cs" />

--- a/src/Mapster/Models/AccessModifier.cs
+++ b/src/Mapster/Models/AccessModifier.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Mapster.Models
+{
+    [Flags]
+    public enum AccessModifier
+    {
+        None = 0,
+        Private = 1,
+        Protected = 2,
+        Internal = 4,
+        Public = 8,
+    }
+}

--- a/src/Mapster/Models/ClassModel.cs
+++ b/src/Mapster/Models/ClassModel.cs
@@ -6,6 +6,6 @@ namespace Mapster.Models
     internal class ClassModel
     {
         public ConstructorInfo ConstructorInfo { get; set; }
-        public List<IMemberModel> Members { get; set; } 
+        public IEnumerable<IMemberModel> Members { get; set; } 
     }
 }

--- a/src/Mapster/Models/FieldModel.cs
+++ b/src/Mapster/Models/FieldModel.cs
@@ -16,7 +16,10 @@ namespace Mapster.Models
         public Type Type => _fieldInfo.FieldType;
         public string Name => _fieldInfo.Name;
         public object Info => _fieldInfo;
-        public bool HasSetter => !_fieldInfo.IsInitOnly;
+        public AccessModifier SetterModifier
+        {
+            get { return _fieldInfo.IsInitOnly ? AccessModifier.None : AccessModifier.Public; }
+        }
 
         public Expression GetExpression(Expression source)
         {

--- a/src/Mapster/Models/IMemberModel.cs
+++ b/src/Mapster/Models/IMemberModel.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace Mapster.Models
 {
-    internal interface IMemberModel
+    public interface IMemberModel
     {
         Type Type { get; }
         string Name { get; }
         object Info { get; }
-        bool HasSetter { get; }
+        AccessModifier SetterModifier { get; }
 
         Expression GetExpression(Expression source);
         IEnumerable<object> GetCustomAttributes(bool inherit);

--- a/src/Mapster/Models/MemberMapping.cs
+++ b/src/Mapster/Models/MemberMapping.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq.Expressions;
-using System.Reflection;
+﻿using System.Linq.Expressions;
 
 namespace Mapster.Models
 {
@@ -8,8 +6,6 @@ namespace Mapster.Models
     {
         public Expression Getter;
         public Expression Setter;
-
-        public byte ConvertType; //Primitive = 1, FlatteningGetMethod = 2, FlatteningDeep = 3, Adapter = 4, CustomResolve = 5;
 
         public object SetterInfo;
     }

--- a/src/Mapster/Models/ParameterModel.cs
+++ b/src/Mapster/Models/ParameterModel.cs
@@ -15,7 +15,7 @@ namespace Mapster.Models
         }
 
         public Type Type => _parameterInfo.ParameterType;
-        public string Name => _parameterInfo.Name.ToProperCase();
+        public string Name => _parameterInfo.Name.ToPascalCase();
         public object Info => _parameterInfo;
         public AccessModifier SetterModifier => AccessModifier.None;
 

--- a/src/Mapster/Models/ParameterModel.cs
+++ b/src/Mapster/Models/ParameterModel.cs
@@ -17,7 +17,7 @@ namespace Mapster.Models
         public Type Type => _parameterInfo.ParameterType;
         public string Name => _parameterInfo.Name.ToProperCase();
         public object Info => _parameterInfo;
-        public bool HasSetter => false;
+        public AccessModifier SetterModifier => AccessModifier.None;
 
         public Expression GetExpression(Expression source)
         {

--- a/src/Mapster/Models/PropertyModel.cs
+++ b/src/Mapster/Models/PropertyModel.cs
@@ -16,7 +16,26 @@ namespace Mapster.Models
         public Type Type => _propertyInfo.PropertyType;
         public string Name => _propertyInfo.Name;
         public object Info => _propertyInfo;
-        public bool HasSetter => _propertyInfo.GetSetMethod() != null;
+
+        public AccessModifier SetterModifier
+        {
+            get
+            {
+                var setter = _propertyInfo.GetSetMethod();
+                if (setter == null)
+                    return AccessModifier.None;
+
+                if (setter.IsFamilyOrAssembly)
+                    return AccessModifier.Protected | AccessModifier.Internal;
+                if (setter.IsFamily)
+                    return AccessModifier.Protected;
+                if (setter.IsAssembly)
+                    return AccessModifier.Internal;
+                if (setter.IsPublic)
+                    return AccessModifier.Public;
+                return AccessModifier.Private;
+            }
+        }
 
         public Expression GetExpression(Expression source)
         {

--- a/src/Mapster/NameMatchingStrategy.cs
+++ b/src/Mapster/NameMatchingStrategy.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mapster
+{
+    public class NameMatchingStrategy
+    {
+        public Func<string, string> SourceMemberNameConverter { get; set; }
+        public Func<string, string> DestinationMemberNameConverter { get; set; }
+
+        public void Apply(NameMatchingStrategy other)
+        {
+            if (this.SourceMemberNameConverter == null)
+                this.SourceMemberNameConverter = other.SourceMemberNameConverter;
+            if (this.DestinationMemberNameConverter == null)
+                this.DestinationMemberNameConverter = other.DestinationMemberNameConverter;
+        }
+
+        public static readonly NameMatchingStrategy Exact = new NameMatchingStrategy
+        {
+            SourceMemberNameConverter = Identity,
+            DestinationMemberNameConverter = Identity,
+        };
+
+        public static readonly NameMatchingStrategy Flexible = new NameMatchingStrategy
+        {
+            SourceMemberNameConverter = ToPascalCase,
+            DestinationMemberNameConverter = ToPascalCase,
+        };
+
+        private static string Identity(string s) => s;
+
+        private static string ToPascalCase(string s) => string.Join("", BreakWords(s).Select(ToProperCase));
+
+        private static string ToProperCase(string s) => s.Length == 0 ? s : (char.ToUpper(s[0]) + s.Substring(1).ToLower());
+
+        private static IEnumerable<string> BreakWords(string s)
+        {
+            var words = new List<string>();
+
+            foreach (var word in s.Split('_'))
+            {
+                if (word.All(char.IsUpper))
+                    words.Add(word);
+                else
+                    words.AddRange(SplitWord(word));
+            }
+
+            return words;
+        }
+
+        private static IEnumerable<string> SplitWord(string s)
+        {
+            var len = s.Length;
+            var pos = 0;
+            var last = 0;
+
+            while (pos < len)
+            {
+                var c = s[pos];
+                if (char.IsUpper(c))
+                {
+                    if (last < pos)
+                    {
+                        yield return s.Substring(last, pos - last);
+                        last = pos;
+                    }
+                }
+                pos++;
+            }
+            if (last < pos)
+                yield return s.Substring(last, pos - last);
+        }
+    }
+}

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -57,7 +57,8 @@ namespace Mapster
             this.Rules = RulesTemplate.ToList();
             var settings = new TypeAdapterSettings
             {
-                ValueAccessingStrategies = ValueAccessingStrategiesTemplate.ToList()
+                ValueAccessingStrategies = ValueAccessingStrategiesTemplate.ToList(),
+                NameMatchingStrategy = NameMatchingStrategy.Exact,
             };
             this.Default = new TypeAdapterSetter(settings, this);
             this.Rules.Add(new TypeAdapterRule

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -27,6 +27,7 @@ namespace Mapster
                 new PrimitiveAdapter().CreateRule(),
                 new RecordTypeAdapter().CreateRule(),
                 new ClassAdapter().CreateRule(),
+                new DictionaryAdapter().CreateRule(),
                 new CollectionAdapter().CreateRule(),
             };
         }

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -79,14 +79,6 @@ namespace Mapster
             setter.Settings.NoInherit = value;
             return setter;
         }
-
-        public static TSetter ValueAccessStrategy<TSetter>(this TSetter setter, Func<Expression, IMemberModel, CompileArgument, Expression> value) where TSetter : TypeAdapterSetter
-        {
-            setter.CheckCompiled();
-
-            setter.Settings.ValueAccessingStrategies.Add(value);
-            return setter;
-        }
     }
 
     public class TypeAdapterSetter<TDestination> : TypeAdapterSetter

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -79,6 +79,14 @@ namespace Mapster
             setter.Settings.NoInherit = value;
             return setter;
         }
+
+        public static TSetter ValueAccessStrategy<TSetter>(this TSetter setter, Func<Expression, IMemberModel, CompileArgument, Expression> value) where TSetter : TypeAdapterSetter
+        {
+            setter.CheckCompiled();
+
+            setter.Settings.ValueAccessingStrategies.Add(value);
+            return setter;
+        }
     }
 
     public class TypeAdapterSetter<TDestination> : TypeAdapterSetter

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -79,6 +79,14 @@ namespace Mapster
             setter.Settings.NoInherit = value;
             return setter;
         }
+
+        public static TSetter NameMatchingStrategy<TSetter>(this TSetter setter, NameMatchingStrategy value) where TSetter : TypeAdapterSetter
+        {
+            setter.CheckCompiled();
+
+            setter.Settings.NameMatchingStrategy = value;
+            return setter;
+        }
     }
 
     public class TypeAdapterSetter<TDestination> : TypeAdapterSetter

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -154,7 +154,7 @@ namespace Mapster
             : base(settings, parentConfig)
         { }
 
-        public TypeAdapterSetter<TSource, TDestination> Ignore(params Expression<Func<TDestination, object>>[] members)
+        public new TypeAdapterSetter<TSource, TDestination> Ignore(params Expression<Func<TDestination, object>>[] members)
         {
             this.CheckCompiled();
 

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -17,9 +17,8 @@ namespace Mapster
     {
         public HashSet<string> IgnoreMembers { get; internal set; } = new HashSet<string>();
         public HashSet<Type> IgnoreAttributes { get; internal set; } = new HashSet<Type>();
-        public HashSet<string> IncludeMembers { get; internal set; } = new HashSet<string>();
-        public HashSet<Type> IncludeAttributes { get; internal set; } = new HashSet<Type>(); 
         public TransformsCollection DestinationTransforms { get; internal set; } = new TransformsCollection();
+        public NameMatchingStrategy NameMatchingStrategy { get; internal set; } = new NameMatchingStrategy();
 
         public bool? PreserveReference { get; set; }
         public bool? ShallowCopyForSameType { get; set; }
@@ -56,6 +55,7 @@ namespace Mapster
 
             this.IgnoreMembers.UnionWith(other.IgnoreMembers);
             this.IgnoreAttributes.UnionWith(other.IgnoreAttributes);
+            this.NameMatchingStrategy.Apply(other.NameMatchingStrategy);
             this.DestinationTransforms.TryAdd(other.DestinationTransforms.Transforms);
             this.AfterMappingFactories.AddRange(other.AfterMappingFactories);
 

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Reflection;
 using Mapster.Models;
 
 namespace Mapster
@@ -16,11 +15,11 @@ namespace Mapster
 
     public class TypeAdapterSettings
     {
-        public HashSet<string> IgnoreMembers { get; protected set; } = new HashSet<string>();
-        public HashSet<Type> IgnoreAttributes { get; protected set; } = new HashSet<Type>();
-        public HashSet<string> IncludeMembers { get; protected set; } = new HashSet<string>();
-        public HashSet<Type> IncludeAttributes { get; protected set; } = new HashSet<Type>(); 
-        public TransformsCollection DestinationTransforms { get; protected set; } = new TransformsCollection();
+        public HashSet<string> IgnoreMembers { get; internal set; } = new HashSet<string>();
+        public HashSet<Type> IgnoreAttributes { get; internal set; } = new HashSet<Type>();
+        public HashSet<string> IncludeMembers { get; internal set; } = new HashSet<string>();
+        public HashSet<Type> IncludeAttributes { get; internal set; } = new HashSet<Type>(); 
+        public TransformsCollection DestinationTransforms { get; internal set; } = new TransformsCollection();
 
         public bool? PreserveReference { get; set; }
         public bool? ShallowCopyForSameType { get; set; }
@@ -28,11 +27,12 @@ namespace Mapster
         public bool? NoInherit { get; set; }
         public Type DestinationType { get; set; }
 
-        public List<InvokerModel> Resolvers { get; protected set; } = new List<InvokerModel>();
+        public List<Func<Expression, IMemberModel, CompileArgument, Expression>> ValueAccessingStrategies { get; internal set; } = new List<Func<Expression, IMemberModel, CompileArgument, Expression>>();
+        public List<InvokerModel> Resolvers { get; internal set; } = new List<InvokerModel>();
         public Func<CompileArgument, LambdaExpression> ConstructUsingFactory { get; set; }
         public Func<CompileArgument, LambdaExpression> ConverterFactory { get; set; }
         public Func<CompileArgument, LambdaExpression> ConverterToTargetFactory { get; set; }
-        public List<Func<CompileArgument, LambdaExpression>> AfterMappingFactories { get; protected set; } = new List<Func<CompileArgument, LambdaExpression>>();
+        public List<Func<CompileArgument, LambdaExpression>> AfterMappingFactories { get; internal set; } = new List<Func<CompileArgument, LambdaExpression>>();
 
         internal bool Compiled { get; set; }
 
@@ -59,6 +59,7 @@ namespace Mapster
             this.DestinationTransforms.TryAdd(other.DestinationTransforms.Transforms);
             this.AfterMappingFactories.AddRange(other.AfterMappingFactories);
 
+            this.ValueAccessingStrategies.AddRange(other.ValueAccessingStrategies);
             this.Resolvers.AddRange(other.Resolvers);
 
             if (this.ConstructUsingFactory == null)

--- a/src/Mapster/Utils/Extensions.cs
+++ b/src/Mapster/Utils/Extensions.cs
@@ -9,9 +9,9 @@ namespace Mapster.Utils
             return new HashSet<T>(source);
         }
 
-        public static string ToProperCase(this string name)
+        public static string ToPascalCase(this string name)
         {
-            return name.Substring(0, 1).ToUpper() + name.Substring(1);
+            return NameMatchingStrategy.ToPascalCase(name);
         }
 
         public static U GetValueOrDefault<T, U>(this IDictionary<T, U> dict, T key)

--- a/src/Mapster/Utils/Extensions.cs
+++ b/src/Mapster/Utils/Extensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Mapster.Utils
 {
@@ -16,6 +12,12 @@ namespace Mapster.Utils
         public static string ToProperCase(this string name)
         {
             return name.Substring(0, 1).ToUpper() + name.Substring(1);
+        }
+
+        public static U GetValueOrDefault<T, U>(this IDictionary<T, U> dict, T key)
+        {
+            U value;
+            return dict.TryGetValue(key, out value) ? value : default(U);
         }
     }
 }

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -283,7 +283,7 @@ namespace Mapster
 
         public static bool IsConvertible(this Type type)
         {
-            return typeof (IConvertible).GetTypeInfo().IsAssignableFrom(type);
+            return typeof (IConvertible).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo());
         }
 
         public static IMemberModel CreateModel(this PropertyInfo propertyInfo)
@@ -310,17 +310,18 @@ namespace Mapster
 
         public static bool IsListCompatible(this Type type)
         {
-            if (type.IsInterface)
+            var typeInfo = type.GetTypeInfo();
+            if (typeInfo.IsInterface)
                 return type.IsAssignableFromList();
 
-            if (type.IsAbstract)
+            if (typeInfo.IsAbstract)
                 return false;
 
             var elementType = type.ExtractCollectionType();
-            if (typeof(ICollection<>).MakeGenericType(elementType).GetTypeInfo().IsAssignableFrom(type))
+            if (typeof(ICollection<>).MakeGenericType(elementType).GetTypeInfo().IsAssignableFrom(typeInfo))
                 return true;
 
-            if (typeof(IList).GetTypeInfo().IsAssignableFrom(type))
+            if (typeof(IList).GetTypeInfo().IsAssignableFrom(typeInfo))
                 return true;
 
             return false;

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -207,15 +207,17 @@ namespace Mapster
 
         public static Expression GetDeepFlattening(Expression source, string propertyName, CompileArgument arg)
         {
+            var strategy = arg.Settings.NameMatchingStrategy;
             var properties = source.Type.GetPublicFieldsAndProperties();
             foreach (var property in properties)
             {
+                var sourceMemberName = strategy.SourceMemberNameConverter(property.Name);
                 var propertyType = property.Type;
                 if (propertyType.GetTypeInfo().IsClass && propertyType != _stringType
-                    && propertyName.StartsWith(property.Name))
+                    && propertyName.StartsWith(sourceMemberName))
                 {
                     var exp = property.GetExpression(source);
-                    var ifTrue = GetDeepFlattening(exp, propertyName.Substring(property.Name.Length).TrimStart('_'), arg);
+                    var ifTrue = GetDeepFlattening(exp, propertyName.Substring(sourceMemberName.Length).TrimStart('_'), arg);
                     if (ifTrue == null)
                         return null;
                     if (arg.MapType == MapType.Projection)
@@ -225,7 +227,7 @@ namespace Mapster
                         Expression.Constant(ifTrue.Type.GetDefault(), ifTrue.Type),
                         ifTrue);
                 }
-                else if (string.Equals(propertyName, property.Name))
+                else if (string.Equals(propertyName, sourceMemberName))
                 {
                     return property.GetExpression(source);
                 }

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -24,34 +24,17 @@ namespace Mapster
             return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof (Nullable<>);
         }
 
-        public static List<IMemberModel> GetPublicFieldsAndProperties(this Type type, bool allowNonPublicSetter = true, bool allowNoSetter = true)
+        public static IEnumerable<IMemberModel> GetPublicFieldsAndProperties(this Type type, bool allowNonPublicSetter = true, bool allowNoSetter = true)
         {
-            var results = new List<IMemberModel>();
+            var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(x => (allowNoSetter || x.CanWrite) && (allowNonPublicSetter || x.GetSetMethod() != null))
+                .Select(CreateModel);
 
-            results.AddRange(
-                type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                    .Where(x => (allowNoSetter || x.CanWrite) && (allowNonPublicSetter || x.GetSetMethod() != null))
-                    .Select(CreateModel));
+            var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public)
+                .Where(x => (allowNoSetter || !x.IsInitOnly))
+                .Select(CreateModel);
 
-            results.AddRange(
-                type.GetFields(BindingFlags.Instance | BindingFlags.Public)
-                    .Where(x => (allowNoSetter || !x.IsInitOnly))
-                    .Select(CreateModel));
-            
-            return results;
-        }
-
-        public static IMemberModel GetMemberModel(Type type, string name)
-        {
-            var prop = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
-            if (prop != null)
-                return new PropertyModel(prop);
-
-            var field = type.GetField(name, BindingFlags.Public | BindingFlags.Instance);
-            if (field != null)
-                return new FieldModel(field);
-
-            return null;
+            return properties.Concat(fields);
         }
 
         public static bool IsCollection(this Type type)
@@ -222,21 +205,20 @@ namespace Mapster
             return memberExpr;
         }
 
-        public static Expression GetDeepFlattening(Expression source, string propertyName, bool isProjection)
+        public static Expression GetDeepFlattening(Expression source, string propertyName, CompileArgument arg)
         {
             var properties = source.Type.GetPublicFieldsAndProperties();
-            for (int j = 0; j < properties.Count; j++)
+            foreach (var property in properties)
             {
-                var property = properties[j];
                 var propertyType = property.Type;
                 if (propertyType.GetTypeInfo().IsClass && propertyType != _stringType
                     && propertyName.StartsWith(property.Name))
                 {
                     var exp = property.GetExpression(source);
-                    var ifTrue = GetDeepFlattening(exp, propertyName.Substring(property.Name.Length).TrimStart('_'), isProjection);
+                    var ifTrue = GetDeepFlattening(exp, propertyName.Substring(property.Name.Length).TrimStart('_'), arg);
                     if (ifTrue == null)
                         return null;
-                    if (isProjection)
+                    if (arg.MapType == MapType.Projection)
                         return ifTrue;
                     return Expression.Condition(
                         Expression.Equal(exp, Expression.Constant(null, exp.Type)),
@@ -267,7 +249,7 @@ namespace Mapster
             if (type.GetTypeInfo().IsEnum)
                 return false;
 
-            return type.GetPublicFieldsAndProperties(allowNoSetter: false).Count > 0;
+            return type.GetPublicFieldsAndProperties(allowNoSetter: false).Any();
         }
 
         public static bool IsRecordType(this Type type)
@@ -285,8 +267,8 @@ namespace Mapster
                 return false;
 
             //no setter
-            var props = type.GetPublicFieldsAndProperties();
-            if (props.Any(p => p.HasSetter))
+            var props = type.GetPublicFieldsAndProperties().ToList();
+            if (props.Any(p => p.SetterModifier != AccessModifier.None))
                 return false;
 
             //1 non-empty constructor
@@ -342,6 +324,11 @@ namespace Mapster
                 return true;
 
             return false;
+        }
+
+        public static Type GetDictionaryType(this Type destinationType)
+        {
+            return destinationType.GetInterface(type => type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(IDictionary<,>));
         }
     }
 }

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -279,8 +279,8 @@ namespace Mapster
                 return false;
 
             //all parameters should match getter
-            var names = props.Select(p => p.Name).ToHashSet();
-            return names.SetEquals(ctors[0].GetParameters().Select(p => p.Name.ToProperCase()));
+            var names = props.Select(p => p.Name.ToPascalCase()).ToHashSet();
+            return names.SetEquals(ctors[0].GetParameters().Select(p => p.Name.ToPascalCase()));
         }
 
         public static bool IsConvertible(this Type type)

--- a/src/Mapster/ValueAccessingStrategy.cs
+++ b/src/Mapster/ValueAccessingStrategy.cs
@@ -58,7 +58,9 @@ namespace Mapster
         private static Expression PropertyOrFieldFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
         {
             var members = source.Type.GetPublicFieldsAndProperties();
-            return members.Where(member => member.Name == destinationMember.Name)
+            var strategy = arg.Settings.NameMatchingStrategy;
+            var destinationMemberName = strategy.DestinationMemberNameConverter(destinationMember.Name);
+            return members.Where(member => strategy.SourceMemberNameConverter(member.Name) == destinationMemberName)
                 .Select(member => member.GetExpression(source))
                 .FirstOrDefault();
         }
@@ -73,7 +75,9 @@ namespace Mapster
 
         private static Expression FlattenMemberFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
         {
-            return ReflectionUtils.GetDeepFlattening(source, destinationMember.Name, arg);
+            var strategy = arg.Settings.NameMatchingStrategy;
+            var destinationMemberName = strategy.DestinationMemberNameConverter(destinationMember.Name);
+            return ReflectionUtils.GetDeepFlattening(source, destinationMemberName, arg);
         }
 
         private static Expression DictionaryFn(Expression source, IMemberModel destinationMember, CompileArgument arg)

--- a/src/Mapster/ValueAccessingStrategy.cs
+++ b/src/Mapster/ValueAccessingStrategy.cs
@@ -69,7 +69,10 @@ namespace Mapster
         {
             if (arg.MapType == MapType.Projection)
                 return null;
-            var getMethod = source.Type.GetMethod(string.Concat("Get", destinationMember.Name), BindingFlags.Public | BindingFlags.Instance);
+            var strategy = arg.Settings.NameMatchingStrategy;
+            var destinationMemberName = "Get" + strategy.DestinationMemberNameConverter(destinationMember.Name);
+            var getMethod = source.Type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(m => strategy.SourceMemberNameConverter(m.Name) == destinationMemberName);
             return getMethod != null ? Expression.Call(source, getMethod) : null;
         }
 

--- a/src/Mapster/ValueAccessingStrategy.cs
+++ b/src/Mapster/ValueAccessingStrategy.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Mapster.Models;
+using Mapster.Utils;
+
+namespace Mapster
+{
+    public static class ValueAccessingStrategy
+    {
+        public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> CustomResolver = CustomResolverFn;
+        public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> PropertyOrField = PropertyOrFieldFn;
+        public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> GetMethod = GetMethodFn;
+        public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> FlattenMember = FlattenMemberFn;
+        public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> Dictionary = DictionaryFn;
+
+        internal static List<Func<Expression, IMemberModel, CompileArgument, Expression>> GetDefaultStrategies()
+        {
+            return new List<Func<Expression, IMemberModel, CompileArgument, Expression>>
+            {
+                CustomResolver,
+                PropertyOrField,
+                GetMethod,
+                FlattenMember,
+            };
+        }
+
+        private static Expression CustomResolverFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        {
+            var config = arg.Settings;
+            var resolvers = config.Resolvers;
+            if (resolvers == null || resolvers.Count <= 0)
+                return null;
+
+            Expression getter = null;
+            LambdaExpression lastCondition = null;
+            for (int j = 0; j < resolvers.Count; j++)
+            {
+                var resolver = resolvers[j];
+                if (destinationMember.Name.Equals(resolver.MemberName))
+                {
+                    Expression invoke = resolver.Invoker.Apply(source);
+                    getter = lastCondition != null
+                        ? Expression.Condition(lastCondition.Apply(source), getter, invoke)
+                        : invoke;
+                    lastCondition = resolver.Condition;
+                    if (resolver.Condition == null)
+                        break;
+                }
+            }
+            if (lastCondition != null)
+                getter = Expression.Condition(lastCondition.Apply(source), getter, Expression.Constant(getter.Type.GetDefault(), getter.Type));
+            return getter;
+        }
+
+        private static Expression PropertyOrFieldFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        {
+            var members = source.Type.GetPublicFieldsAndProperties();
+            return members.Where(member => member.Name == destinationMember.Name)
+                .Select(member => member.GetExpression(source))
+                .FirstOrDefault();
+        }
+
+        private static Expression GetMethodFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        {
+            if (arg.MapType == MapType.Projection)
+                return null;
+            var getMethod = source.Type.GetMethod(string.Concat("Get", destinationMember.Name), BindingFlags.Public | BindingFlags.Instance);
+            return getMethod != null ? Expression.Call(source, getMethod) : null;
+        }
+
+        private static Expression FlattenMemberFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        {
+            return ReflectionUtils.GetDeepFlattening(source, destinationMember.Name, arg);
+        }
+
+        private static Expression DictionaryFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        {
+            var dictType = source.Type.GetDictionaryType();
+            if (dictType == null)
+                return null;
+            var args = dictType.GetGenericArguments();
+            var method = typeof (Extensions).GetMethods().First(m => m.Name == "GetValueOrDefault").MakeGenericMethod(args);
+            return Expression.Call(method, source.To(dictType), Expression.Constant(destinationMember.Name));
+        }
+    }
+}


### PR DESCRIPTION
Fix #49 

Pls merge #56 before reviewing this issue.

This PR allows match property names with different convention. Usage is

```
TypeAdapterConfig.GlobalSettings.Default.NameMatchingStrategy(NameMatchingStrategy.Flexible);
```

or

```
TypeAdapterConfig<Foo, Bar>.NewConfig().NameMatchingStrategy(NameMatchingStrategy.Flexible);
```

By defining as flexible, it will allow to match between `PascalCase`, `camelCase`, `lower_case`, and `UPPER_CASE`. This feature is applied to both property mapping & class flattening. And users can defined their own convention (ie, prefix, suffix, replace) by create new NameMatchingStrategy.