### PR TITLE
IgnoreIf() - conditional ignoring of properties mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,14 @@ Mapster will automatically map properties with the same names. You can ignore me
         .NewConfig()
         .Ignore(dest => dest.Id);
 
+You can ignore members conditionally, with condition based on source or target. When the condition is met, mapping of the property
+will be skipped altogether. This is the difference from custom `Map` with condition, where destination is set to `null`
+when condition is met.
+
+    TypeAdapterConfig<TSource, TDestination>
+        .NewConfig()
+        .IgnoreIf((src, dest) => !string.IsNullOrEmpty(dest.Name), dest => dest.Name);
+
 You can ignore members annotated with specific attributes by using the `IgnoreAttribute` method.
 
     TypeAdapterConfig<TSource, TDestination>

--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="WhenCloningConfig.cs" />
     <Compile Include="WhenCompilingConfig.cs" />
     <Compile Include="WhenCreatingConfigInstance.cs" />
+    <Compile Include="WhenIgnoringConditionally.cs" />
     <Compile Include="WhenMappingDerived.cs" />
     <Compile Include="WhenMappingWithDictionary.cs" />
     <Compile Include="WhenMappingRecordTypes.cs" />

--- a/src/Mapster.Tests/WhenIgnoringConditionally.cs
+++ b/src/Mapster.Tests/WhenIgnoringConditionally.cs
@@ -1,0 +1,148 @@
+﻿using NUnit.Framework;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestFixture]
+    public class WhenIgnoringConditionally
+    {
+
+        #region Tests
+
+        [Test]
+        public void True_Constant_Ignores_Map()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .IgnoreIf((src, dest) => true, dest => dest.Name)
+                .Compile();
+
+            var poco = new SimplePoco { Id = 1, Name = "TestName" };
+            SimpleDto dto = TypeAdapter.Adapt<SimplePoco, SimpleDto>(poco);
+
+            dto.Id.ShouldBe(1);
+            dto.Name.ShouldBeNull();
+        }
+
+        [Test]
+        public void True_Constant_Ignores_Map_To_Target()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .IgnoreIf((src, dest) => true, dest => dest.Name)
+                .Compile();
+
+            var poco = new SimplePoco { Id = 1, Name = "TestName" };
+            var dto = new SimpleDto { Id = 999, Name = "DtoName" };
+            TypeAdapter.Adapt(poco, dto);
+
+            dto.Id.ShouldBe(1);
+            dto.Name.ShouldBe("DtoName");
+        }
+
+        [Test]
+        public void True_Condition_Ignores_Map()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .IgnoreIf((src, dest) => src.Name == "TestName", dest => dest.Name)
+                .Compile();
+
+            var poco = new SimplePoco { Id = 1, Name = "TestName" };
+            SimpleDto dto = TypeAdapter.Adapt<SimplePoco, SimpleDto>(poco);
+
+            dto.Id.ShouldBe(1);
+            dto.Name.ShouldBeNull();
+        }
+
+        [Test]
+        public void True_Condition_Ignores_Map_To_Target()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .IgnoreIf((src, dest) => src.Name == "TestName", dest => dest.Name)
+                .Compile();
+
+            var poco = new SimplePoco { Id = 1, Name = "TestName" };
+            var dto = new SimpleDto { Id = 999, Name = "DtoName" };
+            TypeAdapter.Adapt(poco, dto);
+
+            dto.Id.ShouldBe(1);
+            dto.Name.ShouldBe("DtoName");
+        }
+
+        [Test]
+        public void Null_Condition_Ignores_Map()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .IgnoreIf(null, dest => dest.Name)
+                .Compile();
+
+            var poco = new SimplePoco { Id = 1, Name = "TestName" };
+            var dto = TypeAdapter.Adapt<SimplePoco, SimpleDto>(poco);
+
+            dto.Id.ShouldBe(1);
+            dto.Name.ShouldBeNull();
+        }
+
+        [Test]
+        public void Null_Condition_Ignores_Map_To_Target()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .IgnoreIf(null, dest => dest.Name)
+                .Compile();
+
+            var poco = new SimplePoco { Id = 1, Name = "TestName" };
+            var dto = new SimpleDto { Id = 999, Name = "DtoName" };
+            TypeAdapter.Adapt(poco, dto);
+
+            dto.Id.ShouldBe(1);
+            dto.Name.ShouldBe("DtoName");
+        }
+
+        [Test]
+        public void True_Condition_On_Target_Ignores_Map()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .IgnoreIf((src, dest) => !string.IsNullOrEmpty(dest.Name), dest => dest.Name)
+                .Compile();
+
+            var poco = new SimplePoco { Id = 1, Name = "TestName" };
+            var dto = TypeAdapter.Adapt<SimplePoco, SimpleDto>(poco);
+
+            dto.Id.ShouldBe(1);
+            dto.Name.ShouldBe("TestName");
+        }
+
+        [Test]
+        public void True_Condition_On_Target_Ignores_Map_To_Target()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .IgnoreIf((src, dest) => !string.IsNullOrEmpty(dest.Name), dest => dest.Name)
+                .Compile();
+
+            var poco = new SimplePoco { Id = 1, Name = "TestName" };
+            var dto = new SimpleDto { Id = 999, Name = "DtoName" };
+            TypeAdapter.Adapt(poco, dto);
+
+            dto.Id.ShouldBe(1);
+            dto.Name.ShouldBe("DtoName");
+        }
+
+        #endregion
+
+
+        #region TestClasses
+
+        public class SimplePoco
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        public class SimpleDto
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        #endregion
+
+    }
+}

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Mapster.Models;
 using Mapster.Utils;
+using System.Linq;
 
 namespace Mapster.Adapters
 {
@@ -54,6 +55,8 @@ namespace Mapster.Adapters
         protected virtual bool CanInline(Expression source, Expression destination, CompileArgument arg)
         {
             if (arg.MapType == MapType.MapToTarget)
+                return false;
+            if (arg.Settings.IgnoreMembers.Any(item => item.Value != null))
                 return false;
             var constructUsing = arg.Settings.ConstructUsingFactory?.Invoke(arg);
             if (constructUsing != null &&

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -4,13 +4,14 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Mapster.Models;
+using Mapster.Utils;
 
 namespace Mapster.Adapters
 {
     /// <summary>
     /// Maps one class to another.
     /// </summary>
-    /// <remarks>The operations in this class must be extremely fast.  Make sure to benchmark before making **any** changes in here.  
+    /// <remarks>The operations in this class must be extremely fast.  Make sure to benchmark before making **any** changes in here.
     /// The core Adapt method is critically important to performance.
     /// </remarks>
     internal class ClassAdapter : BaseClassAdapter
@@ -63,6 +64,11 @@ namespace Mapster.Adapters
                 {
                     var condition = Expression.NotEqual(property.Getter, Expression.Constant(null, property.Getter.Type));
                     itemAssign = Expression.IfThen(condition, itemAssign);
+                }
+
+                if (property.SetterCondition != null)
+                {
+                    itemAssign = Expression.IfThen(Expression.Not(property.SetterCondition.Apply(source, destination)), itemAssign);
                 }
                 lines.Add(itemAssign);
             }

--- a/src/Mapster/Models/MemberMapping.cs
+++ b/src/Mapster/Models/MemberMapping.cs
@@ -8,5 +8,6 @@ namespace Mapster.Models
         public Expression Setter;
 
         public object SetterInfo;
+        public LambdaExpression SetterCondition;
     }
 }

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -36,7 +36,10 @@ namespace Mapster
         {
             setter.CheckCompiled();
 
-            setter.Settings.IgnoreMembers.UnionWith(names);
+            foreach (var name in names)
+            {
+                setter.Settings.IgnoreMembers[name] = null;
+            }
             return setter;
         }
 
@@ -99,10 +102,12 @@ namespace Mapster
         {
             this.CheckCompiled();
 
-            Settings.IgnoreMembers.UnionWith(members.Select(member => ReflectionUtils.GetMemberInfo(member).Member.Name));
+            foreach (var member in members)
+            {
+                Settings.IgnoreMembers[ReflectionUtils.GetMemberInfo(member).Member.Name] = null;
+            }
             return this;
         }
-
 
         public TypeAdapterSetter<TDestination> Map<TDestinationMember, TSourceMember>(
             Expression<Func<TDestination, TDestinationMember>> member,
@@ -158,7 +163,23 @@ namespace Mapster
         {
             this.CheckCompiled();
 
-            Settings.IgnoreMembers.UnionWith(members.Select(member => ReflectionUtils.GetMemberInfo(member).Member.Name));
+            foreach (var member in members)
+            {
+                Settings.IgnoreMembers[ReflectionUtils.GetMemberInfo(member).Member.Name] = null;
+            }
+            return this;
+        }
+
+        public TypeAdapterSetter<TSource, TDestination> IgnoreIf(
+            Expression<Func<TSource, TDestination, bool>> condition,
+            params Expression<Func<TDestination, object>>[] members)
+        {
+            this.CheckCompiled();
+
+            foreach (var member in members)
+            {
+                Settings.IgnoreMembers[ReflectionUtils.GetMemberInfo(member).Member.Name] = condition;
+            }
             return this;
         }
 

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -15,7 +15,7 @@ namespace Mapster
 
     public class TypeAdapterSettings
     {
-        public HashSet<string> IgnoreMembers { get; internal set; } = new HashSet<string>();
+        public Dictionary<string, LambdaExpression> IgnoreMembers { get; internal set; } = new Dictionary<string, LambdaExpression>();
         public HashSet<Type> IgnoreAttributes { get; internal set; } = new HashSet<Type>();
         public TransformsCollection DestinationTransforms { get; internal set; } = new TransformsCollection();
         public NameMatchingStrategy NameMatchingStrategy { get; internal set; } = new NameMatchingStrategy();
@@ -53,7 +53,10 @@ namespace Mapster
             if (this.IgnoreNullValues == null)
                 this.IgnoreNullValues = other.IgnoreNullValues;
 
-            this.IgnoreMembers.UnionWith(other.IgnoreMembers);
+            foreach (var member in other.IgnoreMembers)
+            {
+                this.IgnoreMembers[member.Key] = member.Value;
+            }
             this.IgnoreAttributes.UnionWith(other.IgnoreAttributes);
             this.NameMatchingStrategy.Apply(other.NameMatchingStrategy);
             this.DestinationTransforms.TryAdd(other.DestinationTransforms.Transforms);


### PR DESCRIPTION
Addresses the issue #77.

We need to skip mapping according to some condition, but `Map` with condition sets target to `null`, when condition is met.

I implemented `IgnoreIf` configuration. It ignores mapping the similar way as standard `Ignore`, **but only when condition is met.** This condition takes as arguments both, source and destination objects.

```csharp
TypeAdapterConfig<TSource, TDestination>
    .NewConfig()
    .IgnoreIf((src, dest) => !string.IsNullOrEmpty(dest.Name), dest => dest.Name);
```
