### PR TITLE
Private fields accessing strategy

### DIFF
--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="WhenCreatingConfigInstance.cs" />
     <Compile Include="WhenIgnoringConditionally.cs" />
     <Compile Include="WhenMappingDerived.cs" />
+    <Compile Include="WhenMappingPrivateFieldsAndProperties.cs" />
     <Compile Include="WhenMappingWithDictionary.cs" />
     <Compile Include="WhenMappingRecordTypes.cs" />
     <Compile Include="WhenMappingIgnoreNullValues.cs" />

--- a/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
+++ b/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
@@ -109,7 +109,7 @@ namespace Mapster.Tests
         private void SetUpMappingNonPublicFields<TSource, TDestination>()
         {
             var config = TypeAdapterConfig<TSource, TDestination>.NewConfig();
-            config.ParentConfig.EnableNonPublicMembers();
+            config.EnableNonPublicMembers();
             config.NameMatchingStrategy(NameMatchingStrategy.Flexible);
         }
 
@@ -117,7 +117,6 @@ namespace Mapster.Tests
         {
             TypeAdapterConfig<TSource, TDestination>
                   .NewConfig()
-                  .ParentConfig
                   .EnableNonPublicMembers();
 
         }

--- a/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
+++ b/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestFixture]
+    public class WhenMappingPrivateFieldsAndProperties
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            TypeAdapterConfig.GlobalSettings.Clear();
+        }
+
+        [Test]
+        public void Default_Settings_Should_Not_Map_Private_Fields()
+        {
+            TypeAdapterConfig<CustomerWithPrivateField, CustomerDTO>
+                .NewConfig()
+                .NameMatchingStrategy(NameMatchingStrategy.Flexible);
+
+            var customerId = 1;
+            var aCustomer = new CustomerWithPrivateField(customerId);
+
+            var dto = aCustomer.Adapt<CustomerDTO>();
+
+            dto.Id.ShouldNotBe(customerId);
+        }
+
+        [Test]
+        public void Default_Settings_Should_Not_Map_Private_Properties()
+        {
+            var customerName = "Customer 1";
+            var aCustomer = new CustomerWithPrivateProperty(customerName);
+
+            var dto = aCustomer.Adapt<CustomerDTO>();
+
+            dto.Name.ShouldNotBe(customerName);
+        }
+
+        [Test]
+        public void Should_Map_Private_Field_To_New_Object_Correctly()
+        {
+            SetUpMappingPrivateFields();
+
+            var customerId = 1;
+            var aCustomer = new CustomerWithPrivateField(customerId);
+
+            var dto = aCustomer.Adapt<CustomerDTO>();
+
+            dto.Id.ShouldBe(customerId);
+        }
+
+        [Test]
+        public void Should_Map_Private_Property_To_New_Object_Correctly()
+        {
+            SetUpMappingPrivateProperties();
+
+            var customerName = "Customer 1";
+            var aCustomer = new CustomerWithPrivateProperty(customerName);
+
+            var dto = aCustomer.Adapt<CustomerDTO>();
+
+            dto.Name.ShouldBe(customerName);
+        }
+
+        private void SetUpMappingPrivateFields()
+        {
+            var config = TypeAdapterConfig<CustomerWithPrivateField, CustomerDTO>.NewConfig();
+            config.Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.PrivatePropertyOrField);
+            config.NameMatchingStrategy(NameMatchingStrategy.Flexible);
+        }
+
+        private void SetUpMappingPrivateProperties()
+        {
+            TypeAdapterConfig<CustomerWithPrivateProperty, CustomerDTO>
+                  .NewConfig()
+                      .Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.PrivatePropertyOrField);
+
+        }
+
+        #region Test Classes
+
+        public class CustomerWithPrivateField
+        {
+            private int _id;
+
+            private CustomerWithPrivateField() { }
+
+            public CustomerWithPrivateField(int id)
+            {
+                _id = id;
+            }
+
+            public bool HasId(int id)
+            {
+                return _id == id;
+            }
+        }
+
+        public class CustomerWithPrivateProperty
+        {
+            private string Name { get; set; }
+
+            private CustomerWithPrivateProperty() { }
+
+            public CustomerWithPrivateProperty(string name)
+            {
+                Name = name;
+            }
+
+            public bool HasName(string name)
+            {
+                return Name == name;
+            }
+        }
+
+        public class CustomerDTO
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
+++ b/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Shouldly;
 
 namespace Mapster.Tests
@@ -11,74 +6,116 @@ namespace Mapster.Tests
     [TestFixture]
     public class WhenMappingPrivateFieldsAndProperties
     {
-        [TearDown]
-        public void TearDown()
-        {
-            TypeAdapterConfig.GlobalSettings.Clear();
-        }
-
         [Test]
-        public void Default_Settings_Should_Not_Map_Private_Fields()
+        public void Default_Settings_Should_Not_Map_Private_Fields_To_New_Object()
         {
             TypeAdapterConfig<CustomerWithPrivateField, CustomerDTO>
                 .NewConfig()
                 .NameMatchingStrategy(NameMatchingStrategy.Flexible);
 
             var customerId = 1;
-            var aCustomer = new CustomerWithPrivateField(customerId);
+            var customerName = "Customer 1";
+            var aCustomer = new CustomerWithPrivateField(customerId, customerName);
 
             var dto = aCustomer.Adapt<CustomerDTO>();
 
+            Assert.NotNull(dto);
             dto.Id.ShouldNotBe(customerId);
+            dto.Name.ShouldBe(customerName);
         }
 
         [Test]
-        public void Default_Settings_Should_Not_Map_Private_Properties()
+        public void Default_Settings_Should_Not_Map_Private_Properties_To_New_Object()
         {
+            var customerId = 1;
             var customerName = "Customer 1";
-            var aCustomer = new CustomerWithPrivateProperty(customerName);
+            var aCustomer = new CustomerWithPrivateProperty(customerId, customerName);
 
             var dto = aCustomer.Adapt<CustomerDTO>();
 
+            Assert.NotNull(dto);
+            dto.Id.ShouldBe(customerId);
             dto.Name.ShouldNotBe(customerName);
         }
 
         [Test]
         public void Should_Map_Private_Field_To_New_Object_Correctly()
         {
-            SetUpMappingPrivateFields();
+            SetUpMappingPrivateFields<CustomerWithPrivateField, CustomerDTO>();
 
             var customerId = 1;
-            var aCustomer = new CustomerWithPrivateField(customerId);
+            var customerName = "Customer 1";
+            var aCustomer = new CustomerWithPrivateField(customerId, customerName);
 
             var dto = aCustomer.Adapt<CustomerDTO>();
 
+            Assert.NotNull(dto);
             dto.Id.ShouldBe(customerId);
+            dto.Name.ShouldBe(customerName);
         }
 
         [Test]
         public void Should_Map_Private_Property_To_New_Object_Correctly()
         {
-            SetUpMappingPrivateProperties();
+            SetUpMappingPrivateProperties<CustomerWithPrivateProperty, CustomerDTO>();
 
+            var customerId = 1;
             var customerName = "Customer 1";
-            var aCustomer = new CustomerWithPrivateProperty(customerName);
+            var aCustomer = new CustomerWithPrivateProperty(customerId, customerName);
 
             var dto = aCustomer.Adapt<CustomerDTO>();
 
+            Assert.NotNull(dto);
+            dto.Id.ShouldBe(customerId);
             dto.Name.ShouldBe(customerName);
         }
 
-        private void SetUpMappingPrivateFields()
+        [Test]
+        public void Should_Map_To_Private_Fields_Correctly()
         {
-            var config = TypeAdapterConfig<CustomerWithPrivateField, CustomerDTO>.NewConfig();
+            SetUpMappingPrivateFields<CustomerDTO, CustomerWithPrivateField>();
+            
+            var dto = new CustomerDTO
+            {
+                Id = 1,
+                Name = "Customer 1"
+            };
+
+            var customer = dto.Adapt<CustomerWithPrivateField>();
+
+            Assert.NotNull(customer);
+            Assert.IsTrue(customer.HasId(dto.Id));
+            customer.Name.ShouldBe(dto.Name);            
+        }
+
+        [Test]
+        public void Should_Map_To_Private_Properties_Correctly()
+        {
+            SetUpMappingPrivateFields<CustomerDTO, CustomerWithPrivateProperty>();
+
+            var dto = new CustomerDTO
+            {
+                Id = 1,
+                Name = "Customer 1"
+            };
+
+            var customer = dto.Adapt<CustomerWithPrivateProperty>();
+
+            Assert.NotNull(customer);
+            customer.Id.ShouldBe(dto.Id);
+            Assert.IsTrue(customer.HasName(dto.Name));
+        }
+
+        private void SetUpMappingPrivateFields<TSource, TDestination>()
+        {
+            var config = TypeAdapterConfig<TSource, TDestination>.NewConfig();
             config.Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.PrivatePropertyOrField);
             config.NameMatchingStrategy(NameMatchingStrategy.Flexible);
         }
 
-        private void SetUpMappingPrivateProperties()
+        private void SetUpMappingPrivateProperties<TSource, TDestination>()
         {
-            TypeAdapterConfig<CustomerWithPrivateProperty, CustomerDTO>
+            TypeAdapterConfig<TSource, TDestination>
                   .NewConfig()
                       .Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.PrivatePropertyOrField);
 
@@ -89,12 +126,14 @@ namespace Mapster.Tests
         public class CustomerWithPrivateField
         {
             private int _id;
+            public string Name { get; private set; }
 
             private CustomerWithPrivateField() { }
 
-            public CustomerWithPrivateField(int id)
+            public CustomerWithPrivateField(int id, string name)
             {
                 _id = id;
+                Name = name;
             }
 
             public bool HasId(int id)
@@ -105,12 +144,14 @@ namespace Mapster.Tests
 
         public class CustomerWithPrivateProperty
         {
+            public int Id { get; private set; }
             private string Name { get; set; }
 
             private CustomerWithPrivateProperty() { }
 
-            public CustomerWithPrivateProperty(string name)
+            public CustomerWithPrivateProperty(int id, string name)
             {
+                Id = id;
                 Name = name;
             }
 

--- a/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
+++ b/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
@@ -109,7 +109,7 @@ namespace Mapster.Tests
         private void SetUpMappingNonPublicFields<TSource, TDestination>()
         {
             var config = TypeAdapterConfig<TSource, TDestination>.NewConfig();
-            config.Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.NonPublicPropertyOrField);
+            config.ParentConfig.EnableNonPublicMembers();
             config.NameMatchingStrategy(NameMatchingStrategy.Flexible);
         }
 
@@ -117,7 +117,8 @@ namespace Mapster.Tests
         {
             TypeAdapterConfig<TSource, TDestination>
                   .NewConfig()
-                      .Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.NonPublicPropertyOrField);
+                  .ParentConfig
+                  .EnableNonPublicMembers();
 
         }
 

--- a/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
+++ b/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
@@ -41,7 +41,7 @@ namespace Mapster.Tests
         [Test]
         public void Should_Map_Private_Field_To_New_Object_Correctly()
         {
-            SetUpMappingPrivateFields<CustomerWithPrivateField, CustomerDTO>();
+            SetUpMappingNonPublicFields<CustomerWithPrivateField, CustomerDTO>();
 
             var customerId = 1;
             var customerName = "Customer 1";
@@ -57,7 +57,7 @@ namespace Mapster.Tests
         [Test]
         public void Should_Map_Private_Property_To_New_Object_Correctly()
         {
-            SetUpMappingPrivateProperties<CustomerWithPrivateProperty, CustomerDTO>();
+            SetUpMappingNonPublicProperties<CustomerWithPrivateProperty, CustomerDTO>();
 
             var customerId = 1;
             var customerName = "Customer 1";
@@ -73,7 +73,7 @@ namespace Mapster.Tests
         [Test]
         public void Should_Map_To_Private_Fields_Correctly()
         {
-            SetUpMappingPrivateFields<CustomerDTO, CustomerWithPrivateField>();
+            SetUpMappingNonPublicFields<CustomerDTO, CustomerWithPrivateField>();
             
             var dto = new CustomerDTO
             {
@@ -91,7 +91,7 @@ namespace Mapster.Tests
         [Test]
         public void Should_Map_To_Private_Properties_Correctly()
         {
-            SetUpMappingPrivateFields<CustomerDTO, CustomerWithPrivateProperty>();
+            SetUpMappingNonPublicFields<CustomerDTO, CustomerWithPrivateProperty>();
 
             var dto = new CustomerDTO
             {
@@ -106,18 +106,18 @@ namespace Mapster.Tests
             Assert.IsTrue(customer.HasName(dto.Name));
         }
 
-        private void SetUpMappingPrivateFields<TSource, TDestination>()
+        private void SetUpMappingNonPublicFields<TSource, TDestination>()
         {
             var config = TypeAdapterConfig<TSource, TDestination>.NewConfig();
-            config.Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.PrivatePropertyOrField);
+            config.Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.NonPublicPropertyOrField);
             config.NameMatchingStrategy(NameMatchingStrategy.Flexible);
         }
 
-        private void SetUpMappingPrivateProperties<TSource, TDestination>()
+        private void SetUpMappingNonPublicProperties<TSource, TDestination>()
         {
             TypeAdapterConfig<TSource, TDestination>
                   .NewConfig()
-                      .Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.PrivatePropertyOrField);
+                      .Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.NonPublicPropertyOrField);
 
         }
 

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -23,11 +23,10 @@ namespace Mapster.Adapters
             if (sourceType == typeof(string) || sourceType == typeof(object))
                 return false;
 
-            if (destinationType.GetTypeInfo().IsEnum || destinationType.Namespace.StartsWith("System"))
+            if (!destinationType.IsPoco())
                 return false;
 
-            return (destinationType.GetFieldsAndProperties(allowNoSetter: false).Any() ||
-                    destinationType.GetFieldsAndProperties(allowNoSetter: false, isNonPublic: true).Any());
+            return true;
         }
 
         protected override bool CanInline(Expression source, Expression destination, CompileArgument arg)
@@ -37,8 +36,6 @@ namespace Mapster.Adapters
             if (arg.MapType != MapType.Projection &&
                 arg.Settings.IgnoreNullValues == true)
                 return false;
-            if (arg.DestinationType.GetFieldsAndProperties(isNonPublic: true).Any())
-                return false;            
             return true;
         }
 
@@ -128,7 +125,6 @@ namespace Mapster.Adapters
             return new ClassModel
             {
                 Members = destinationType.GetFieldsAndProperties(allowNoSetter: false)
-                    .Concat(destinationType.GetFieldsAndProperties(allowNoSetter: false, isNonPublic: true))
             };
         }
     }

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -26,8 +26,8 @@ namespace Mapster.Adapters
             if (destinationType.GetTypeInfo().IsEnum || destinationType.Namespace.StartsWith("System"))
                 return false;
 
-            return (destinationType.GetPublicFieldsAndProperties(allowNoSetter: false).Any() ||
-                    destinationType.GetPrivateFieldsAndProperties(allowNoSetter: false).Any());
+            return (destinationType.GetFieldsAndProperties(allowNoSetter: false).Any() ||
+                    destinationType.GetFieldsAndProperties(allowNoSetter: false, isNonPublic: true).Any());
         }
 
         protected override bool CanInline(Expression source, Expression destination, CompileArgument arg)
@@ -37,7 +37,7 @@ namespace Mapster.Adapters
             if (arg.MapType != MapType.Projection &&
                 arg.Settings.IgnoreNullValues == true)
                 return false;
-            if (arg.DestinationType.GetPrivateFieldsAndProperties().Any())
+            if (arg.DestinationType.GetFieldsAndProperties(isNonPublic: true).Any())
                 return false;            
             return true;
         }
@@ -127,8 +127,8 @@ namespace Mapster.Adapters
         {
             return new ClassModel
             {
-                Members = destinationType.GetPublicFieldsAndProperties(allowNoSetter: false)
-                    .Concat(destinationType.GetPrivateFieldsAndProperties(allowNoSetter: false))
+                Members = destinationType.GetFieldsAndProperties(allowNoSetter: false)
+                    .Concat(destinationType.GetFieldsAndProperties(allowNoSetter: false, isNonPublic: true))
             };
         }
     }

--- a/src/Mapster/Adapters/ClassWithNonPublicMemberAdapter.cs
+++ b/src/Mapster/Adapters/ClassWithNonPublicMemberAdapter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Mapster.Models;
 
@@ -8,36 +6,11 @@ namespace Mapster.Adapters
 {
     internal class ClassWithNonPublicMemberAdapter : ClassAdapter
     {
-        protected override bool CanMap(Type sourceType, Type destinationType, MapType mapType)
-        {
-            if (sourceType == typeof(string) || sourceType == typeof(object))
-                return false;
-
-            if (destinationType.GetTypeInfo().IsEnum || destinationType.Namespace.StartsWith("System"))
-                return false;
-
-            return (destinationType.GetFieldsAndProperties(allowNoSetter: false).Any() ||
-                    destinationType.GetFieldsAndProperties(allowNoSetter: false, isNonPublic: true).Any());
-        }
-
-        protected override bool CanInline(Expression source, Expression destination, CompileArgument arg)
-        {
-            if (!base.CanInline(source, destination, arg))
-                return false;
-            if (arg.MapType != MapType.Projection &&
-                arg.Settings.IgnoreNullValues == true)
-                return false;
-            if (arg.DestinationType.GetFieldsAndProperties(isNonPublic: true).Any())
-                return false;
-            return true;
-        }
-
         protected override ClassModel GetClassModel(Type destinationType)
         {
             return new ClassModel
             {
-                Members = destinationType.GetFieldsAndProperties(allowNoSetter: false)
-                    .Concat(destinationType.GetFieldsAndProperties(allowNoSetter: false, isNonPublic: true))
+                Members = destinationType.GetFieldsAndProperties(allowNoSetter: false, accessorFlags: BindingFlags.Public | BindingFlags.NonPublic)
             };
         }
     }

--- a/src/Mapster/Adapters/ClassWithNonPublicMemberAdapter.cs
+++ b/src/Mapster/Adapters/ClassWithNonPublicMemberAdapter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Mapster.Models;
+
+namespace Mapster.Adapters
+{
+    internal class ClassWithNonPublicMemberAdapter : ClassAdapter
+    {
+        protected override bool CanMap(Type sourceType, Type destinationType, MapType mapType)
+        {
+            if (sourceType == typeof(string) || sourceType == typeof(object))
+                return false;
+
+            if (destinationType.GetTypeInfo().IsEnum || destinationType.Namespace.StartsWith("System"))
+                return false;
+
+            return (destinationType.GetFieldsAndProperties(allowNoSetter: false).Any() ||
+                    destinationType.GetFieldsAndProperties(allowNoSetter: false, isNonPublic: true).Any());
+        }
+
+        protected override bool CanInline(Expression source, Expression destination, CompileArgument arg)
+        {
+            if (!base.CanInline(source, destination, arg))
+                return false;
+            if (arg.MapType != MapType.Projection &&
+                arg.Settings.IgnoreNullValues == true)
+                return false;
+            if (arg.DestinationType.GetFieldsAndProperties(isNonPublic: true).Any())
+                return false;
+            return true;
+        }
+
+        protected override ClassModel GetClassModel(Type destinationType)
+        {
+            return new ClassModel
+            {
+                Members = destinationType.GetFieldsAndProperties(allowNoSetter: false)
+                    .Concat(destinationType.GetFieldsAndProperties(allowNoSetter: false, isNonPublic: true))
+            };
+        }
+    }
+}

--- a/src/Mapster/Adapters/DictionaryAdapter.cs
+++ b/src/Mapster/Adapters/DictionaryAdapter.cs
@@ -58,7 +58,7 @@ namespace Mapster.Adapters
                 setMethod = typeof (Extensions).GetMethods().First(m => m.Name == "FlexibleSet")
                     .MakeGenericMethod(args[1]);
             }
-            var properties = source.Type.GetPublicFieldsAndProperties();
+            var properties = source.Type.GetFieldsAndProperties();
             foreach (var property in properties)
             {
                 var getter = property.GetExpression(source);
@@ -102,7 +102,7 @@ namespace Mapster.Adapters
                 lines.AddRange(listInit.Initializers);
 
             var nameMatching = arg.Settings.NameMatchingStrategy;
-            var properties = source.Type.GetPublicFieldsAndProperties();
+            var properties = source.Type.GetFieldsAndProperties();
             foreach (var property in properties)
             {
                 var getter = property.GetExpression(source);

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -72,7 +72,7 @@ namespace Mapster.Adapters
 
         protected override ClassModel GetClassModel(Type destinationType)
         {
-            var props = destinationType.GetPublicFieldsAndProperties();
+            var props = destinationType.GetFieldsAndProperties();
             var names = props.Select(p => p.Name.ToPascalCase()).ToHashSet();
             return (from ctor in destinationType.GetConstructors()
                     let ps = ctor.GetParameters()

--- a/src/Mapster/Mapster.csproj
+++ b/src/Mapster/Mapster.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Adapters\BaseAdapter.cs" />
     <Compile Include="Adapters\BaseAfterMapper.cs" />
     <Compile Include="Adapters\BaseClassAdapter.cs" />
+    <Compile Include="Adapters\ClassWithNonPublicMemberAdapter.cs" />
     <Compile Include="Adapters\DictionaryAdapter.cs" />
     <Compile Include="Adapters\RecordTypeAdapter.cs" />
     <Compile Include="IRegister.cs" />

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -493,13 +493,6 @@ namespace Mapster
             var fn = _cloneConfig.GetMapFunction<TypeAdapterConfig, TypeAdapterConfig>();
             return fn(this);
         }
-
-        public void EnableNonPublicMembers()
-        {
-            var rule = new ClassWithNonPublicMemberAdapter().CreateRule();
-            rule.Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.NonPublicPropertyOrField);
-            this.Rules.Add(rule);
-        }
     }
 
     public static class TypeAdapterConfig<TSource, TDestination>

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -493,6 +493,13 @@ namespace Mapster
             var fn = _cloneConfig.GetMapFunction<TypeAdapterConfig, TypeAdapterConfig>();
             return fn(this);
         }
+
+        public void EnableNonPublicMembers()
+        {
+            var rule = new ClassWithNonPublicMemberAdapter().CreateRule();
+            rule.Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.NonPublicPropertyOrField);
+            this.Rules.Add(rule);
+        }
     }
 
     public static class TypeAdapterConfig<TSource, TDestination>

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Mapster.Adapters;
 using Mapster.Models;
 
 namespace Mapster
@@ -196,6 +197,18 @@ namespace Mapster
                 Invoker = source,
                 Condition = shouldMap
             });
+            return this;
+        }
+
+        public TypeAdapterSetter<TSource, TDestination> EnableNonPublicMembers()
+        {
+            this.CheckCompiled();
+
+            var adapter = new ClassWithNonPublicMemberAdapter();
+            Settings.ConverterFactory = adapter.CreateAdaptFunc;
+            Settings.ConverterToTargetFactory = adapter.CreateAdaptToTargetFunc;
+            Settings.ValueAccessingStrategies.Add(ValueAccessingStrategy.NonPublicPropertyOrField);
+
             return this;
         }
 

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -33,25 +33,19 @@ namespace Mapster
             return type.GetFieldsAndProperties(allowNoSetter: false).Any();
         }
 
-        public static IEnumerable<IMemberModel> GetFieldsAndProperties(this Type type, bool allowNonPublicSetter = true, bool allowNoSetter = true, bool isNonPublic = false)
+        public static IEnumerable<IMemberModel> GetFieldsAndProperties(this Type type, bool allowNonPublicSetter = true, bool allowNoSetter = true, BindingFlags accessorFlags = BindingFlags.Public)
         {
-            var bindingFlags = BindingFlags.Instance |
-                               (isNonPublic ? BindingFlags.NonPublic : BindingFlags.Public);
+            var bindingFlags = BindingFlags.Instance | accessorFlags;
 
             var properties = type.GetProperties(bindingFlags)
                 .Where(x => (allowNoSetter || x.CanWrite) && (allowNonPublicSetter || x.GetSetMethod() != null))
                 .Select(CreateModel);
 
             var fields = type.GetFields(bindingFlags)
-                .Where(x => (allowNoSetter || !x.IsInitOnly) && !IsBackingField(x))
+                .Where(x => (allowNoSetter || !x.IsInitOnly))
                 .Select(CreateModel);
 
             return properties.Concat(fields);
-        }
-
-        private static bool IsBackingField(FieldInfo field)
-        {
-            return field.CustomAttributes.Any(a => a.AttributeType == typeof(CompilerGeneratedAttribute));
         }
 
         public static bool IsCollection(this Type type)

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -25,26 +25,16 @@ namespace Mapster
             return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof (Nullable<>);
         }
 
-        public static IEnumerable<IMemberModel> GetPublicFieldsAndProperties(this Type type, bool allowNonPublicSetter = true, bool allowNoSetter = true)
+        public static IEnumerable<IMemberModel> GetFieldsAndProperties(this Type type, bool allowNonPublicSetter = true, bool allowNoSetter = true, bool isNonPublic = false)
         {
-            var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            var bindingFlags = BindingFlags.Instance |
+                               (isNonPublic ? BindingFlags.NonPublic : BindingFlags.Public);
+
+            var properties = type.GetProperties(bindingFlags)
                 .Where(x => (allowNoSetter || x.CanWrite) && (allowNonPublicSetter || x.GetSetMethod() != null))
                 .Select(CreateModel);
 
-            var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public)
-                .Where(x => (allowNoSetter || !x.IsInitOnly))
-                .Select(CreateModel);
-
-            return properties.Concat(fields);
-        }
-
-        public static IEnumerable<IMemberModel> GetPrivateFieldsAndProperties(this Type type, bool allowNoSetter = true)
-        {
-            var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.NonPublic)
-                .Where(x => allowNoSetter || x.CanWrite)
-                .Select(CreateModel);
-
-            var fields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+            var fields = type.GetFields(bindingFlags)
                 .Where(x => (allowNoSetter || !x.IsInitOnly) && !IsBackingField(x))
                 .Select(CreateModel);
 
@@ -227,7 +217,7 @@ namespace Mapster
         public static Expression GetDeepFlattening(Expression source, string propertyName, CompileArgument arg)
         {
             var strategy = arg.Settings.NameMatchingStrategy;
-            var properties = source.Type.GetPublicFieldsAndProperties();
+            var properties = source.Type.GetFieldsAndProperties();
             foreach (var property in properties)
             {
                 var sourceMemberName = strategy.SourceMemberNameConverter(property.Name);
@@ -280,7 +270,7 @@ namespace Mapster
                 return false;
 
             //no setter
-            var props = type.GetPublicFieldsAndProperties().ToList();
+            var props = type.GetFieldsAndProperties().ToList();
             if (props.Any(p => p.SetterModifier != AccessModifier.None))
                 return false;
 

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -37,6 +37,19 @@ namespace Mapster
             return properties.Concat(fields);
         }
 
+        public static IEnumerable<IMemberModel> GetPrivateFieldsAndProperties(this Type type, bool allowNoSetter = true)
+        {
+            var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.NonPublic)
+                .Where(x => allowNoSetter || x.CanWrite)
+                .Select(CreateModel);
+
+            var fields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                .Where(x => (allowNoSetter || !x.IsInitOnly))
+                .Select(CreateModel);
+
+            return properties.Concat(fields);
+        }
+
         public static bool IsCollection(this Type type)
         {
             return typeof (IEnumerable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()) && type != _stringType;

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -25,6 +25,14 @@ namespace Mapster
             return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof (Nullable<>);
         }
 
+        public static bool IsPoco(this Type type)
+        {
+            if (type.GetTypeInfo().IsEnum)
+                return false;
+
+            return type.GetFieldsAndProperties(allowNoSetter: false).Any();
+        }
+
         public static IEnumerable<IMemberModel> GetFieldsAndProperties(this Type type, bool allowNonPublicSetter = true, bool allowNoSetter = true, bool isNonPublic = false)
         {
             var bindingFlags = BindingFlags.Instance |

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Mapster.Models;
 using Mapster.Utils;
 
@@ -44,10 +45,15 @@ namespace Mapster
                 .Select(CreateModel);
 
             var fields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
-                .Where(x => (allowNoSetter || !x.IsInitOnly))
+                .Where(x => (allowNoSetter || !x.IsInitOnly) && !IsBackingField(x))
                 .Select(CreateModel);
 
             return properties.Concat(fields);
+        }
+
+        private static bool IsBackingField(FieldInfo field)
+        {
+            return field.CustomAttributes.Any(a => a.AttributeType == typeof(CompilerGeneratedAttribute));
         }
 
         public static bool IsCollection(this Type type)
@@ -257,14 +263,6 @@ namespace Mapster
                 return true;
 
             return false;
-        }
-
-        public static bool IsPoco(this Type type)
-        {
-            if (type.GetTypeInfo().IsEnum)
-                return false;
-
-            return type.GetPublicFieldsAndProperties(allowNoSetter: false).Any();
         }
 
         public static bool IsRecordType(this Type type)

--- a/src/Mapster/ValueAccessingStrategy.cs
+++ b/src/Mapster/ValueAccessingStrategy.cs
@@ -60,9 +60,7 @@ namespace Mapster
         {
             return (source, destinationMember, arg) =>
             {
-                var members = nonPublicPropertyOrField ?
-                    source.Type.GetFieldsAndProperties(isNonPublic: true) :
-                    source.Type.GetFieldsAndProperties();
+                var members = source.Type.GetFieldsAndProperties(accessorFlags: nonPublicPropertyOrField ? BindingFlags.NonPublic : BindingFlags.Public);
                 var strategy = arg.Settings.NameMatchingStrategy;
                 var destinationMemberName = strategy.DestinationMemberNameConverter(destinationMember.Name);
                 return members.Where(member => strategy.SourceMemberNameConverter(member.Name) == destinationMemberName)

--- a/src/Mapster/ValueAccessingStrategy.cs
+++ b/src/Mapster/ValueAccessingStrategy.cs
@@ -12,7 +12,7 @@ namespace Mapster
     {
         public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> CustomResolver = CustomResolverFn;
         public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> PropertyOrField = PropertyOrFieldFn(false);
-        public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> PrivatePropertyOrField = PropertyOrFieldFn(true);
+        public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> NonPublicPropertyOrField = PropertyOrFieldFn(true);
         public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> GetMethod = GetMethodFn;
         public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> FlattenMember = FlattenMemberFn;
         public static readonly Func<Expression, IMemberModel, CompileArgument, Expression> Dictionary = DictionaryFn;
@@ -56,13 +56,13 @@ namespace Mapster
             return getter;
         }
 
-        private static Func<Expression, IMemberModel, CompileArgument, Expression> PropertyOrFieldFn(bool privatePropertyOrField)
+        private static Func<Expression, IMemberModel, CompileArgument, Expression> PropertyOrFieldFn(bool nonPublicPropertyOrField)
         {
             return (source, destinationMember, arg) =>
             {
-                var members = privatePropertyOrField ?
-                    source.Type.GetPrivateFieldsAndProperties() :
-                    source.Type.GetPublicFieldsAndProperties();
+                var members = nonPublicPropertyOrField ?
+                    source.Type.GetFieldsAndProperties(isNonPublic: true) :
+                    source.Type.GetFieldsAndProperties();
                 var strategy = arg.Settings.NameMatchingStrategy;
                 var destinationMemberName = strategy.DestinationMemberNameConverter(destinationMember.Name);
                 return members.Where(member => strategy.SourceMemberNameConverter(member.Name) == destinationMemberName)


### PR DESCRIPTION
Hi,

I just created a private fields/properties accessing strategy (ValueAccessingStrategy.PrivatePropertyOrField), could you help to take a look?

A few things to note:

- I don't include this accessing strategy in default strategy list, since it might be a special case and I think better let users to choose whether to use it or not
- In ClassAdapter.CanMap(), I choose to ignore all types from System namespace since those should have other adapter handle already
- In ClassAdapter.CanInline(), if destination class has any private property, we cannot use inline expression   and have to use block expression (to use Expression.Assign())
- In ClassAdapter.CanInline() and ClassAdapter.GetClassModel(), probably can optimize further by checking whether user specifies ValueAccessingStrategy.PrivatePropertyOrField. But I'm not sure how to do that without massively change other classes at the moment.

Thanks

