### PR TITLE
Made GetProjectionCallExpression public instead of internal

### DIFF
--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -238,7 +238,7 @@ namespace Mapster
             return (Expression<Func<TSource, TDestination>>)((UnaryExpression)((MethodCallExpression)del).Arguments[1]).Operand;
         }
 
-        internal MethodCallExpression GetProjectionCallExpression(Type sourceType, Type destinationType)
+        public MethodCallExpression GetProjectionCallExpression(Type sourceType, Type destinationType)
         {
             var key = new TypeTuple(sourceType, destinationType);
             object del = _projectionDict[key] ?? AddToHash(_projectionDict, key, CreateProjectionCallExpression);


### PR DESCRIPTION
In order to successfully create an application wide abstraction for
Mapster, the GetProjectionCallExpression method needs to be public.