### PR TITLE
Object to primitive type is always converted using Convert class. Fixes #94

### DIFF
--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Classes\TypeTestClass.cs" />
     <Compile Include="WhenCloningConfig.cs" />
     <Compile Include="WhenCompilingConfig.cs" />
+    <Compile Include="WhenConvertingFromObjects.cs" />
     <Compile Include="WhenCreatingConfigInstance.cs" />
     <Compile Include="WhenIgnoringConditionally.cs" />
     <Compile Include="WhenMappingDerived.cs" />

--- a/src/Mapster.Tests/WhenConvertingFromObjects.cs
+++ b/src/Mapster.Tests/WhenConvertingFromObjects.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestFixture]
+    class WhenConvertingFromObjects
+    {
+
+        #region TestClasses
+
+        public class SimplePoco
+        {
+            public int Int32 { get; set; }
+            public long Int64 { get; set; }
+        }
+
+        #endregion
+
+        [Test]
+        public void Int32_In_Object_Is_Converted_To_Int64()
+        {
+            var dictionaryData = new Dictionary<string, object>
+                {
+                    { "Int32", 32 },
+                    { "Int64", 64 }
+                };
+
+            var poco = dictionaryData.Adapt<SimplePoco>();
+            poco.Int32.ShouldBe(32);
+            poco.Int64.ShouldBe(64L);
+        }
+    }
+}


### PR DESCRIPTION
Casting to primitive types from object may fail in some cases as described in #94

```csharp
object intValAsObject = 123; // Value is Int32
long longVal = (long)intValAsObject; // Throws InvalidCastException
```

I have changed `ReflectionUtils.BuildUnderlyingTypeConvertExpression` method so it always use `Convert` class (instead of casting) when source type is `object` and destination type is primitive.