### PR TITLE
Multidimensional arrays are correctly mapped.

### DIFF
--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="WhenForkingConfig.cs" />
     <Compile Include="WhenMappingComplexClasses.cs" />
     <Compile Include="WhenMappingDerived.cs" />
+    <Compile Include="WhenMappingArrays.cs" />
     <Compile Include="WhenMappingPrivateFieldsAndProperties.cs" />
     <Compile Include="WhenMappingWithDictionary.cs" />
     <Compile Include="WhenMappingRecordTypes.cs" />

--- a/src/Mapster.Tests/WhenMappingArrays.cs
+++ b/src/Mapster.Tests/WhenMappingArrays.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
-using System;
+using System.Collections.Generic;
 
 namespace Mapster.Tests
 {
@@ -81,6 +81,28 @@ namespace Mapster.Tests
             target.IntsRank3.ShouldBe(source.IntsRank3);
         }
 
+        [TestMethod]
+        public void List_To_Array_Is_Mapped()
+        {
+            var source = new FooList { Ints = new List<int>(new int[] { 1, 2, 3, 4, 5 }) };
+            var target = new BarArray();
+
+            TypeAdapter.Adapt(source, target);
+            target.Ints.Length.ShouldBe(source.Ints.Count);
+            target.Ints.ShouldBe(source.Ints);
+        }
+
+        [TestMethod]
+        public void Array_To_List_Is_Mapped()
+        {
+            var source = new FooArray { Ints = new int[] { 1, 2, 3, 4, 5 } };
+            var target = new BarList();
+
+            TypeAdapter.Adapt(source, target);
+            target.Ints.Count.ShouldBe(source.Ints.Length);
+            target.Ints.ShouldBe(source.Ints);
+        }
+
         #endregion
 
         #region TestClasses
@@ -93,6 +115,16 @@ namespace Mapster.Tests
         private class BarArray
         {
             public int[] Ints { get; set; }
+        }
+
+        private class FooList
+        {
+            public List<int> Ints { get; set; }
+        }
+
+        private class BarList
+        {
+            public List<int> Ints { get; set; }
         }
 
         private class FooArrayMultiDimensional

--- a/src/Mapster.Tests/WhenMappingArrays.cs
+++ b/src/Mapster.Tests/WhenMappingArrays.cs
@@ -13,12 +13,12 @@ namespace Mapster.Tests
         [TestMethod]
         public void Single_Dimensional_Array_Is_Mapped()
         {
-            var a = new FooArray { Ints = new int[] { 1, 2, 3, 4, 5 } };
-            var b = new BarArray();
+            var source = new FooArray { Ints = new int[] { 1, 2, 3, 4, 5 } };
+            var target = new BarArray();
 
-            TypeAdapter.Adapt(a, b);
-            b.Ints.Length.ShouldBe(a.Ints.Length);
-            b.Ints.ShouldBe(a.Ints);
+            TypeAdapter.Adapt(source, target);
+            target.Ints.Length.ShouldBe(source.Ints.Length);
+            target.Ints.ShouldBe(source.Ints);
         }
 
         [TestMethod]

--- a/src/Mapster.Tests/WhenMappingArrays.cs
+++ b/src/Mapster.Tests/WhenMappingArrays.cs
@@ -13,8 +13,8 @@ namespace Mapster.Tests
         [TestMethod]
         public void Single_Dimensional_Array_Is_Mapped()
         {
-            var a = new Foo { Ints = new int[] { 1, 2, 3, 4, 5 } };
-            var b = new Bar();
+            var a = new FooArray { Ints = new int[] { 1, 2, 3, 4, 5 } };
+            var b = new BarArray();
 
             TypeAdapter.Adapt(a, b);
             b.Ints.Length.ShouldBe(a.Ints.Length);
@@ -24,7 +24,7 @@ namespace Mapster.Tests
         [TestMethod]
         public void Multi_Dimensional_Array_Is_Mapped()
         {
-            var source = new FooMulti
+            var source = new FooArrayMultiDimensional
             {
                 IntsRank2 = new int[3, 2] {
                     { 10, 20 },
@@ -37,7 +37,7 @@ namespace Mapster.Tests
                     { {1000, 2000, 3000, 4000 , 5000}, { 6000, 7000, 8000, 9000, 10000 } }
                 }
             };
-            var target = new BarMulti();
+            var target = new BarArrayMultiDimensional();
 
             TypeAdapter.Adapt(source, target);
 
@@ -51,7 +51,7 @@ namespace Mapster.Tests
         [TestMethod]
         public void Jagged_Array_Is_Mapped()
         {
-            var source = new FooJagged
+            var source = new FooArrayJagged
             {
                 IntsRank2 = new int[][] {
                     new int[] { 10, 20 },
@@ -70,7 +70,7 @@ namespace Mapster.Tests
                     }
                 }
             };
-            var target = new BarJagged();
+            var target = new BarArrayJagged();
 
             TypeAdapter.Adapt(source, target);
 
@@ -85,35 +85,35 @@ namespace Mapster.Tests
 
         #region TestClasses
 
-        private class Foo
+        private class FooArray
         {
             public int[] Ints { get; set; }
         }
 
-        private class Bar
+        private class BarArray
         {
             public int[] Ints { get; set; }
         }
 
-        private class FooMulti
+        private class FooArrayMultiDimensional
         {
             public int[,] IntsRank2 { get; set; }
             public int[,,] IntsRank3 { get; set; }
         }
 
-        private class BarMulti
+        private class BarArrayMultiDimensional
         {
             public int[,] IntsRank2 { get; set; }
             public int[,,] IntsRank3 { get; set; }
         }
 
-        private class FooJagged
+        private class FooArrayJagged
         {
             public int[][] IntsRank2 { get; set; }
             public int[][][] IntsRank3 { get; set; }
         }
 
-        private class BarJagged
+        private class BarArrayJagged
         {
             public int[][] IntsRank2 { get; set; }
             public int[][][] IntsRank3 { get; set; }

--- a/src/Mapster.Tests/WhenMappingArrays.cs
+++ b/src/Mapster.Tests/WhenMappingArrays.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using System;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenMappingArrays
+    {
+
+        #region Tests
+
+        [TestMethod]
+        public void Single_Dimensional_Array_Is_Mapped()
+        {
+            var a = new Foo { Ints = new int[] { 1, 2, 3, 4, 5 } };
+            var b = new Bar();
+
+            TypeAdapter.Adapt(a, b);
+            b.Ints.Length.ShouldBe(a.Ints.Length);
+            b.Ints.ShouldBe(a.Ints);
+        }
+
+        [TestMethod]
+        public void Multi_Dimensional_Array_Is_Mapped()
+        {
+            var source = new FooMulti
+            {
+                IntsRank2 = new int[3, 2] {
+                    { 10, 20 },
+                    { 100, 200 },
+                    { 1000, 2000 }
+                },
+                IntsRank3 = new int[3, 2, 5] {
+                    { {10, 20, 30, 40 , 50}, { 60, 70, 80, 90, 100 } },
+                    { {100, 200, 300, 400 , 500}, { 600, 700, 800, 900, 1000 } },
+                    { {1000, 2000, 3000, 4000 , 5000}, { 6000, 7000, 8000, 9000, 10000 } }
+                }
+            };
+            var target = new BarMulti();
+
+            TypeAdapter.Adapt(source, target);
+
+            target.IntsRank2.Rank.ShouldBe(source.IntsRank2.Rank);
+            target.IntsRank2.ShouldBe(source.IntsRank2);
+
+            target.IntsRank3.Rank.ShouldBe(source.IntsRank3.Rank);
+            target.IntsRank3.ShouldBe(source.IntsRank3);
+        }
+
+        [TestMethod]
+        public void Jagged_Array_Is_Mapped()
+        {
+            var source = new FooJagged
+            {
+                IntsRank2 = new int[][] {
+                    new int[] { 10, 20 },
+                    new int[] { 100, 200 , 300, 400, 500 },
+                    new int[] { 1000, 2000, 3000 }
+                },
+                IntsRank3 = new int[][][] {
+                    new int[][] {
+                        new int[]{ 10, 20, 30, 40, 50 },
+                        new int[]{ 60, 70 }
+                    },
+                    new int[][] {
+                        new int[]{ 100, 200, 300 },
+                        new int[]{ 400 },
+                        new int[]{ 500, 600, 700, 800 },
+                    }
+                }
+            };
+            var target = new BarJagged();
+
+            TypeAdapter.Adapt(source, target);
+
+            target.IntsRank2.Rank.ShouldBe(source.IntsRank2.Rank);
+            target.IntsRank2.ShouldBe(source.IntsRank2);
+
+            target.IntsRank3.Rank.ShouldBe(source.IntsRank3.Rank);
+            target.IntsRank3.ShouldBe(source.IntsRank3);
+        }
+
+        #endregion
+
+        #region TestClasses
+
+        private class Foo
+        {
+            public int[] Ints { get; set; }
+        }
+
+        private class Bar
+        {
+            public int[] Ints { get; set; }
+        }
+
+        private class FooMulti
+        {
+            public int[,] IntsRank2 { get; set; }
+            public int[,,] IntsRank3 { get; set; }
+        }
+
+        private class BarMulti
+        {
+            public int[,] IntsRank2 { get; set; }
+            public int[,,] IntsRank3 { get; set; }
+        }
+
+        private class FooJagged
+        {
+            public int[][] IntsRank2 { get; set; }
+            public int[][][] IntsRank3 { get; set; }
+        }
+
+        private class BarJagged
+        {
+            public int[][] IntsRank2 { get; set; }
+            public int[][][] IntsRank3 { get; set; }
+        }
+
+        #endregion
+
+    }
+}

--- a/src/Mapster/Adapters/CollectionAdapter.cs
+++ b/src/Mapster/Adapters/CollectionAdapter.cs
@@ -22,20 +22,15 @@ namespace Mapster.Adapters
 
         private static Expression CreateCountExpression(Expression source, bool allowCountAll)
         {
-            if (source.Type.IsArray)
-                return Expression.ArrayLength(source);
-            else
-            {
-                var countProperty = source.Type.GetProperty("Count");
-                if (countProperty != null)
-                    return Expression.Property(source, countProperty);  //list.Count
-                if (!allowCountAll)
-                    return null;
-                var countMethod = typeof(Enumerable).GetMethods()
-                    .First(m => m.Name == nameof(Enumerable.Count) && m.GetParameters().Length == 1)
-                    .MakeGenericMethod(source.Type.ExtractCollectionType());
-                return Expression.Call(countMethod, source);            //list.Count()
-            }
+            var countProperty = source.Type.GetProperty("Count");
+            if (countProperty != null)
+                return Expression.Property(source, countProperty);  //list.Count
+            if (!allowCountAll)
+                return null;
+            var countMethod = typeof(Enumerable).GetMethods()
+                .First(m => m.Name == nameof(Enumerable.Count) && m.GetParameters().Length == 1)
+                .MakeGenericMethod(source.Type.ExtractCollectionType());
+            return Expression.Call(countMethod, source);            //list.Count()
         }
 
         protected override bool CanInline(Expression source, Expression destination, CompileArgument arg)
@@ -51,7 +46,7 @@ namespace Mapster.Adapters
                 throw new InvalidOperationException($"{arg.DestinationType} is not supported for projection, please consider using List<>");
             }
 
-            if (arg.DestinationType == typeof (IEnumerable) || arg.DestinationType.IsGenericEnumerableType())
+            if (arg.DestinationType == typeof(IEnumerable) || arg.DestinationType.IsGenericEnumerableType())
                 return true;
 
             return false;
@@ -59,21 +54,21 @@ namespace Mapster.Adapters
 
         protected override Expression CreateInstantiationExpression(Expression source, Expression destination, CompileArgument arg)
         {
-            var destinationElementType = arg.DestinationType.ExtractCollectionType();
             if (arg.DestinationType.IsArray)
-                return Expression.NewArrayBounds(
-                    destinationElementType, 
-                    CreateCountExpression(source, true));   //new TDestinationElement[count]
+            {
+                return CreateArrayInstantiationExpression(source, arg);
+            }
 
+            var destinationElementType = arg.DestinationType.ExtractCollectionType();
             var count = CreateCountExpression(source, false);
             var listType = arg.DestinationType.GetTypeInfo().IsInterface
-                ? typeof (List<>).MakeGenericType(destinationElementType)
+                ? typeof(List<>).MakeGenericType(destinationElementType)
                 : arg.DestinationType;
             if (count == null)
                 return Expression.New(listType);            //new List<T>()
             var ctor = (from c in listType.GetConstructors()
                         let args = c.GetParameters()
-                        where args.Length == 1 && args[0].ParameterType == typeof (int)
+                        where args.Length == 1 && args[0].ParameterType == typeof(int)
                         select c).FirstOrDefault();
             if (ctor == null)
                 return Expression.New(listType);            //new List<T>()
@@ -81,17 +76,32 @@ namespace Mapster.Adapters
                 return Expression.New(ctor, count);         //new List<T>(count)
         }
 
+        protected Expression CreateArrayInstantiationExpression(Expression source, CompileArgument arg)
+        {
+            return Expression.NewArrayBounds(arg.DestinationType.GetElementType(), GetArrayBounds(source));
+        }
+
+        private IEnumerable<Expression> GetArrayBounds(Expression source)
+        {
+            MethodInfo method = typeof(Array).GetMethod("GetLength", new[] { typeof(int) });
+            for (int i = 0; i < source.Type.GetArrayRank(); i++)
+            {
+                yield return Expression.Call(source, method, Expression.Constant(i));
+            }
+        }
+
         protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)
         {
             if (destination.Type.IsArray)
             {
-                if (source.Type.IsArray && 
+                if (source.Type.IsArray &&
                     source.Type.GetElementType() == destination.Type.GetElementType() &&
                     source.Type.GetElementType().UnwrapNullable().IsConvertible())
                 {
-                    //Array.Copy(src, 0, dest, 0, src.Length)
-                    var method = typeof (Array).GetMethod("Copy", new[] {typeof (Array), typeof (int), typeof (Array), typeof (int), typeof (int)});
-                    return Expression.Call(method, source, Expression.Constant(0), destination, Expression.Constant(0), Expression.ArrayLength(source));
+                    //Array.Copy(src, 0, dest, 0, src.LongLength)
+                    var getLongLengthExpression = Expression.Call(source, typeof(Array).GetMethod("get_LongLength"));
+                    var method = typeof(Array).GetMethod("Copy", new[] { typeof(Array), typeof(long), typeof(Array), typeof(long), typeof(long) });
+                    return Expression.Call(method, source, Expression.Constant((long)0), destination, Expression.Constant((long)0), getLongLengthExpression);
                 }
                 else
                     return CreateArraySet(source, destination, arg);
@@ -105,7 +115,7 @@ namespace Mapster.Adapters
                 var tmp = Expression.Variable(listType, "list");
                 var assign = ExpressionEx.Assign(tmp, destination); //convert to list type
                 var set = CreateListSet(source, tmp, arg);
-                return Expression.Block(new[] {tmp}, assign, set);
+                return Expression.Block(new[] { tmp }, assign, set);
             }
         }
 
@@ -140,7 +150,7 @@ namespace Mapster.Adapters
             if (exp.Type != arg.DestinationType)
             {
                 //src.Select(item => convert(item)).ToList()
-                var toList = (from m in typeof (Enumerable).GetMethods()
+                var toList = (from m in typeof(Enumerable).GetMethods()
                               where m.Name == nameof(Enumerable.ToList)
                               select m).First().MakeGenericMethod(destinationElementType);
                 exp = Expression.Call(toList, exp);
@@ -165,14 +175,14 @@ namespace Mapster.Adapters
             var sourceElementType = source.Type.ExtractCollectionType();
             var destinationElementType = destination.Type.ExtractCollectionType();
             var item = Expression.Variable(sourceElementType, "item");
-            var v = Expression.Variable(typeof (int), "v");
+            var v = Expression.Variable(typeof(int), "v");
             var start = Expression.Assign(v, Expression.Constant(0));
             var getter = CreateAdaptExpression(item, destinationElementType, arg);
             var set = Expression.Assign(
                 Expression.ArrayAccess(destination, Expression.PostIncrementAssign(v)),
                 getter);
             var loop = ForLoop(source, item, set);
-            return Expression.Block(new[] {v}, start, loop);
+            return Expression.Block(new[] { v }, start, loop);
         }
 
         private Expression CreateListSet(Expression source, Expression destination, CompileArgument arg)
@@ -191,8 +201,8 @@ namespace Mapster.Adapters
             var destinationElementType = destination.Type.ExtractCollectionType();
             var item = Expression.Variable(sourceElementType, "item");
             var getter = CreateAdaptExpression(item, destinationElementType, arg);
-            
-            var addMethod = destination.Type.GetMethod("Add", new[] {destinationElementType});
+
+            var addMethod = destination.Type.GetMethod("Add", new[] { destinationElementType });
             var set = Expression.Call(
                 destination,
                 addMethod,
@@ -258,13 +268,13 @@ namespace Mapster.Adapters
         internal static Expression ForEach(Expression collection, ParameterExpression loopVar, params Expression[] loopContent)
         {
             var elementType = loopVar.Type;
-            var enumerableType = typeof (IEnumerable<>).MakeGenericType(elementType);
-            var enumeratorType = typeof (IEnumerator<>).MakeGenericType(elementType);
+            var enumerableType = typeof(IEnumerable<>).MakeGenericType(elementType);
+            var enumeratorType = typeof(IEnumerator<>).MakeGenericType(elementType);
             var isGeneric = enumerableType.GetTypeInfo().IsAssignableFrom(collection.Type.GetTypeInfo());
             if (!isGeneric)
             {
-                enumerableType = typeof (IEnumerable);
-                enumeratorType = typeof (IEnumerator);
+                enumerableType = typeof(IEnumerable);
+                enumeratorType = typeof(IEnumerator);
             }
 
             var enumeratorVar = Expression.Variable(enumeratorType, "enumerator");

--- a/src/Mapster/Adapters/CollectionAdapter.cs
+++ b/src/Mapster/Adapters/CollectionAdapter.cs
@@ -54,7 +54,7 @@ namespace Mapster.Adapters
 
         protected override Expression CreateInstantiationExpression(Expression source, Expression destination, CompileArgument arg)
         {
-            if (arg.DestinationType.IsArray)
+            if (arg.SourceType.IsArray && arg.DestinationType.IsArray)
             {
                 return CreateArrayInstantiationExpression(source, arg);
             }


### PR DESCRIPTION
Fixes #99 - "Argument must be single dimensional array type"

Multidimensional arrays are now correctly created. The significant changes are:

- `Expression.NewArrayBounds()` for instantiating array uses overload which takes arguments for every array's rank.
- Expression for copying array's data (`Array.Copy()`) does not use `Expression.ArrayLength()`, but `arrayVar.LongLength` property.
