### PR TITLE
Map to IEnumerable class is done using ClassAdapter instead of PrimitiveAdapter

### DIFF
--- a/src/Mapster.Tests/WhenMappingIEnumerableClass.cs
+++ b/src/Mapster.Tests/WhenMappingIEnumerableClass.cs
@@ -15,7 +15,6 @@ namespace Mapster.Tests
 
         public class ClassB : IEnumerable
         {
-
             public int Id { get; set; }
 
             public IEnumerator GetEnumerator()
@@ -24,7 +23,7 @@ namespace Mapster.Tests
             }
         }
 
-        [TestMethod, Ignore]
+        [TestMethod]
         public void Map_To_IEnumerable_Class_Should_Pass()
         {
             ClassA classA = new ClassA()

--- a/src/Mapster.Tests/WhenMappingIEnumerableClass.cs
+++ b/src/Mapster.Tests/WhenMappingIEnumerableClass.cs
@@ -15,6 +15,7 @@ namespace Mapster.Tests
 
         public class ClassB : IEnumerable
         {
+
             public int Id { get; set; }
 
             public IEnumerator GetEnumerator()
@@ -23,7 +24,7 @@ namespace Mapster.Tests
             }
         }
 
-        [TestMethod]
+        [TestMethod, Ignore]
         public void Map_To_IEnumerable_Class_Should_Pass()
         {
             ClassA classA = new ClassA()

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -42,6 +42,10 @@ namespace Mapster
 
         public static bool IsPoco(this Type type, BindingFlags accessorFlags = BindingFlags.Public)
         {
+            //not collection
+            if (type.IsCollection())
+                return false;
+
             //not nullable
             if (type.IsNullable())
                 return false;
@@ -165,6 +169,10 @@ namespace Mapster
 
         public static bool IsRecordType(this Type type)
         {
+            //not collection
+            if (type.IsCollection())
+                return false;
+
             //not nullable
             if (type.IsNullable())
                 return false;
@@ -187,7 +195,7 @@ namespace Mapster
             return props.All(prop =>
             {
                 var name = prop.Name.ToPascalCase();
-                return ctors[0].GetParameters().Any(p => p.ParameterType == prop.Type && p.Name?.ToPascalCase() == name);
+                return ctors[0].GetParameters().Any(p => p.ParameterType == prop.Type && p.Name.ToPascalCase() == name);
             });
         }
 

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -42,10 +42,6 @@ namespace Mapster
 
         public static bool IsPoco(this Type type, BindingFlags accessorFlags = BindingFlags.Public)
         {
-            //not collection
-            if (type.IsCollection())
-                return false;
-
             //not nullable
             if (type.IsNullable())
                 return false;
@@ -169,10 +165,6 @@ namespace Mapster
 
         public static bool IsRecordType(this Type type)
         {
-            //not collection
-            if (type.IsCollection())
-                return false;
-
             //not nullable
             if (type.IsNullable())
                 return false;
@@ -195,7 +187,7 @@ namespace Mapster
             return props.All(prop =>
             {
                 var name = prop.Name.ToPascalCase();
-                return ctors[0].GetParameters().Any(p => p.ParameterType == prop.Type && p.Name.ToPascalCase() == name);
+                return ctors[0].GetParameters().Any(p => p.ParameterType == prop.Type && p.Name?.ToPascalCase() == name);
             });
         }
 


### PR DESCRIPTION
This PR fixes #123. The problem is, that `IEnumerable` classes are not recognized as POCO and thus they are adapted using `PrimitiveAdapter` instead of `ClassAdapter`. I think that removing this condition is safe. If both classes are `IEnumerable`, `CollectionAdapter` will be used - it has higher priority than `ClassAdapter`. And basically, class which implements `IEnumerable` still is just a class and can be mapped as such, and not as a primitive type.

I am not sure what exactly is record type, but I made the same change for `RecordTypeAdapter`.