### PR TITLE
Simply Async Extensions

### DIFF
--- a/src/Mapster.Async.Tests/AsyncTest.cs
+++ b/src/Mapster.Async.Tests/AsyncTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using MapsterMapper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
 
@@ -85,6 +86,22 @@ namespace Mapster.Async.Tests
             dtoOwnership.Car.Make.ShouldBe("Car Maker Inc");
             dtoOwnership.Owner.ShouldNotBeNull();
             dtoOwnership.Owner.Name.ShouldBe("John Doe");
+        }
+
+        [TestMethod]
+        public async Task SimplyAsync()
+        {
+            TypeAdapterConfig<Poco, Dto>.NewConfig()
+                .AfterMappingAsync(async dest => { dest.Name = await GetName(); });
+
+            var poco = new Poco { Id = "foo" };
+            var dto = await poco.AdaptAsync<Dto>();
+            dto.Name.ShouldBe("bar");
+
+            IMapper instance = new Mapper();
+
+            var destination = await instance.MapAsync<Dto>(poco);
+            destination.Name.ShouldBe("bar");
         }
 
         private static async Task<string> GetName()

--- a/src/Mapster.Async/TypeAdapterExtensions.cs
+++ b/src/Mapster.Async/TypeAdapterExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MapsterMapper;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -101,5 +102,44 @@ namespace Mapster
             }
         }
 
+
+        /// <summary>
+        /// Map asynchronously to destination type.
+        /// </summary>
+        /// <typeparam name="TDestination">Destination type to map.</typeparam>
+        /// <param name="builder"></param>
+        /// <returns>Type of destination object that mapped.</returns>
+        public static async Task<TDestination> AdaptAsync<TDestination>(this object? source)
+        {
+            return await source.BuildAdapter().AdaptToTypeAsync<TDestination>();
+        }
+
+
+        /// <summary>
+        /// Map asynchronously to destination type.
+        /// </summary>
+        /// <typeparam name="TDestination">Destination type to map.</typeparam>
+        /// <param name="builder"></param>
+        /// <param name="config">Configuration</param>
+        /// <returns>Type of destination object that mapped.</returns>
+        public static async Task<TDestination> AdaptAsync<TDestination>(this object? source, TypeAdapterConfig config)
+        {
+            return await source.BuildAdapter(config).AdaptToTypeAsync<TDestination>();
+        }
+
+    }
+
+    public static class IMapperAsyncExtentions
+    {
+        /// <summary>
+        /// Map asynchronously to destination type.
+        /// </summary>
+        /// <typeparam name="TDestination">Destination type to map.</typeparam>
+        /// <param name="builder"></param>
+        /// <returns>Type of destination object that mapped.</returns>
+        public static async Task<TDestination> MapAsync<TDestination>(this IMapper mapper, object? source)
+        {
+            return await mapper.From(source).AdaptToTypeAsync<TDestination>();
+        }
     }
 }


### PR DESCRIPTION
Add async mapping extensions:

- `AdaptAsync<TDestination>()`
- `MapAsync<TDestination>(source)` from IMapper

Example of use: 

```
var dto = await poco.AdaptAsync<Dto>();

IMapper mapper= new Mapper();
var destination = await mapper.MapAsync<Dto>(poco);
```
