### PR TITLE
Add - Inherits Lazy 

### DIFF
--- a/src/Mapster.Tests/WhenMappingWithExplicitInheritance.cs
+++ b/src/Mapster.Tests/WhenMappingWithExplicitInheritance.cs
@@ -130,15 +130,77 @@ namespace Mapster.Tests
 
         }
 
+        [TestMethod]
+        public void InheritsLasyLoad__IsWork()
+        {
+            TypeAdapterConfig<DerivedPoco, DerivedDto>.NewConfig()
+               .Inherits<SimplePoco, SimpleDto>()
+               .Compile();
+
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .Inherits<RootPoco, RootDto>()
+                .Ignore(dest => dest.Name)
+                .Compile();
+
+            TypeAdapterConfig<RootPoco, RootDto>.NewConfig()
+                .Map(dest => dest.NumberDto, src => 42)
+                .Compile();
+
+            var source = new DerivedPoco
+            {
+                Id = new Guid(),
+                Name = "SourceName"
+            };
+
+            var dto = TypeAdapter.Adapt<DerivedDto>(source);
+
+            dto.Id.ShouldBe(source.Id);
+            dto.Name.ShouldBe("SourceName"); // Inherits Ignore not work
+            dto.NumberDto.ShouldBe(0); // Inherits not work
+
+            Setup(); // clean config
+
+            TypeAdapterConfig<DerivedPoco, DerivedDto>.NewConfig()
+                .InheritsLazy<SimplePoco, SimpleDto>()
+                .Compile();
+
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .InheritsLazy<RootPoco, RootDto>()
+                .Ignore(dest => dest.Name)
+                .Compile();
+
+            TypeAdapterConfig<RootPoco, RootDto>.NewConfig()
+                .Map(dest => dest.NumberDto, src => 42)
+                .Compile();
+
+            dto = TypeAdapter.Adapt<DerivedDto>(source);
+
+            dto.Id.ShouldBe(source.Id);
+            dto.Name.ShouldBeNull();  // InheritsLazy Ignore is work
+            dto.NumberDto.ShouldBe(42); // InheritsLazy is work
+        }
+
+
         #region TestMethod Classes
 
-        public class SimplePoco
+        public class RootPoco
+        {
+            public int Number { get; set; }
+        }
+
+        public class RootDto
+        {
+            public int NumberDto { get; set; }
+        }
+
+
+        public class SimplePoco: RootPoco
         {
             public Guid Id { get; set; }
             public string Name { get; set; }
         }
 
-        public class SimpleDto
+        public class SimpleDto : RootDto
         {
             public Guid Id { get; set; }
             public string Name { get; set; }

--- a/src/Mapster/Models/TypeTuple.cs
+++ b/src/Mapster/Models/TypeTuple.cs
@@ -40,4 +40,50 @@ namespace Mapster.Models
             Destination = destination;
         }
     }
+
+    public class InheritsTypeTuple : IEquatable<InheritsTypeTuple>
+    {
+        public bool Equals(InheritsTypeTuple other)
+        {
+            return Source == other.Source && Destination == other.Destination;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is InheritsTypeTuple))
+                return false;
+            return Equals((InheritsTypeTuple)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Source.GetHashCode() << 16) ^ (Destination.GetHashCode() & 65535);
+        }
+
+        public static bool operator ==(InheritsTypeTuple left, InheritsTypeTuple right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(InheritsTypeTuple left, InheritsTypeTuple right)
+        {
+            return !left.Equals(right);
+        }
+
+        public Type Source { get; }
+        public Type Destination { get; }
+        public bool IsLoading { get; private set; }
+
+        public void IsUploaded()
+        {
+            IsLoading = true;
+        }
+
+        public InheritsTypeTuple(Type source, Type destination)
+        {
+            Source = source;
+            Destination = destination;
+            IsLoading = false;
+        }
+    }
 }

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -317,11 +317,40 @@ namespace Mapster
         }
         internal Delegate GetMapFunction(Type sourceType, Type destinationType)
         {
+            LoadInheritedRulesLazy(new TypeTuple(sourceType, destinationType));
+
             var key = new TypeTuple(sourceType, destinationType);
             if (!_mapDict.TryGetValue(key, out var del))
                 del = AddToHash(_mapDict, key, tuple => Compiler(CreateMapExpression(tuple, MapType.Map)));
             return del;
         }
+
+        private void LoadInheritedRulesLazy(TypeTuple types)
+        {
+            if (RuleMap.TryGetValue(types, out var rule))
+            {
+                if (rule.Settings.InheritsTypeTuples.Count > 0)
+                {
+                    LoadInheritedRules(rule, rule.Settings.InheritsTypeTuples);
+                }
+            }
+        }
+        private void LoadInheritedRules(TypeAdapterRule rule, IEnumerable<InheritsTypeTuple> inheritedTypes)
+        {
+            foreach (var typeTuple in inheritedTypes.Where(t => !t.IsLoading))
+            {
+                if (RuleMap.TryGetValue(new TypeTuple(typeTuple.Source, typeTuple.Destination), out var parentRule))
+                {
+                    rule.LoadLasyInherits(parentRule);
+                    typeTuple.IsUploaded();
+                }
+                if (parentRule != null && parentRule.Settings.InheritsTypeTuples.Any())
+                {
+                    LoadInheritedRules(rule, parentRule.Settings.InheritsTypeTuples);
+                }
+            }
+        }
+
 
         private readonly ConcurrentDictionary<TypeTuple, Delegate> _mapToTargetDict = new ConcurrentDictionary<TypeTuple, Delegate>();
         public Func<TSource, TDestination, TDestination> GetMapToTargetFunction<TSource, TDestination>()
@@ -331,6 +360,9 @@ namespace Mapster
         internal Delegate GetMapToTargetFunction(Type sourceType, Type destinationType)
         {
             var key = new TypeTuple(sourceType, destinationType);
+
+            LoadInheritedRulesLazy(key);
+
             if (!_mapToTargetDict.TryGetValue(key, out var del))
                 del = AddToHash(_mapToTargetDict, key, tuple => Compiler(CreateMapExpression(tuple, MapType.MapToTarget)));
             return del;
@@ -346,6 +378,9 @@ namespace Mapster
         internal MethodCallExpression GetProjectionCallExpression(Type sourceType, Type destinationType)
         {
             var key = new TypeTuple(sourceType, destinationType);
+
+            LoadInheritedRulesLazy(key);
+
             if (!_projectionDict.TryGetValue(key, out var del))
                 del = AddToHash(_projectionDict, key, CreateProjectionCallExpression);
             return del;
@@ -355,6 +390,9 @@ namespace Mapster
         public Func<object, TDestination> GetDynamicMapFunction<TDestination>(Type sourceType)
         {
             var key = new TypeTuple(sourceType, typeof(TDestination));
+
+            LoadInheritedRulesLazy(key);
+
             if (!_dynamicMapDict.TryGetValue(key, out var del))
                 del = AddToHash(_dynamicMapDict, key, tuple => Compiler(CreateDynamicMapExpression(tuple)));
             return (Func<object, TDestination>)del;

--- a/src/Mapster/TypeAdapterRule.cs
+++ b/src/Mapster/TypeAdapterRule.cs
@@ -6,5 +6,10 @@ namespace Mapster
     {
         public Func<PreCompileArgument, int?> Priority { get; set; }
         public TypeAdapterSettings Settings { get; set; }
+
+        public void LoadLasyInherits(TypeAdapterRule rule)
+        {
+            this.Settings.Apply(rule.Settings);
+        }
     }
 }

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -828,6 +828,26 @@ namespace Mapster
             return this;
         }
 
+        public TypeAdapterSetter<TSource, TDestination> InheritsLazy<TBaseSource, TBaseDestination>()
+        {
+            this.CheckCompiled();
+
+            Type baseSourceType = typeof(TBaseSource);
+            Type baseDestinationType = typeof(TBaseDestination);
+
+            if (!baseSourceType.GetTypeInfo().IsAssignableFrom(typeof(TSource).GetTypeInfo()))
+                throw new InvalidCastException("In order to use inherits, TSource must be inherited from TBaseSource.");
+
+            if (!baseDestinationType.GetTypeInfo().IsAssignableFrom(typeof(TDestination).GetTypeInfo()))
+                throw new InvalidCastException("In order to use inherits, TDestination must be inherited from TBaseDestination.");
+
+            Settings.InheritsTypeTuples.Add(new InheritsTypeTuple(baseSourceType, baseDestinationType));
+
+
+            return this;
+        }
+
+
         public TypeAdapterSetter<TSource, TDestination> Fork(Action<TypeAdapterConfig> action)
         {
             this.CheckCompiled();

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -117,6 +117,12 @@ namespace Mapster
         {
             get => Get(nameof(Resolvers), () => new List<InvokerModel>());
         }
+
+        public HashSet<InheritsTypeTuple> InheritsTypeTuples
+        {
+            get => Get(nameof(InheritsTypeTuples), () => new HashSet<InheritsTypeTuple>());
+        }
+
         public List<object> ExtraSources
         {
             get => Get(nameof(ExtraSources), () => new List<object>());


### PR DESCRIPTION
add Setting:
`.InheritsLazy<,>()`

Lazy loads settings for inherited types during the first call to Adapt<>

Example:

```
 TypeAdapterConfig<DerivedPoco, DerivedDto>.NewConfig()
                .InheritsLazy<SimplePoco, SimpleDto>()
                .Compile();

            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
                .InheritsLazy<RootPoco, RootDto>()
                .Ignore(dest => dest.Name)
                .Compile();

            TypeAdapterConfig<RootPoco, RootDto>.NewConfig()
                .Map(dest => dest.NumberDto, src => 42)
                .Compile();

            dto = TypeAdapter.Adapt<DerivedDto>(source);

            dto.Id.ShouldBe(source.Id);
            dto.Name.ShouldBeNull();  // InheritsLazy Ignore is work
            dto.NumberDto.ShouldBe(42); // InheritsLazy is work
```