### PR TITLE
Mapster.EF.Core: Add type check for IAsyncEnumerable<>

### DIFF
--- a/src/Mapster.EFCore.Tests/EFCoreTest.cs
+++ b/src/Mapster.EFCore.Tests/EFCoreTest.cs
@@ -1,11 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Mapster.EFCore.Tests.Models;
 using MapsterMapper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Mapster.EFCore.Tests
 {
@@ -43,6 +44,34 @@ namespace Mapster.EFCore.Tests
             var first = poco.Enrollments.First();
             first.CourseID.ShouldBe(3141);
             first.Grade.ShouldBe(Grade.F);
+        }
+
+        [TestMethod]
+        public async Task TestFindSingleObjectUsingProjectToType()
+        {
+            var options = new DbContextOptionsBuilder<SchoolContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+                .Options;
+            var context = new SchoolContext(options);
+            DbInitializer.Initialize(context);
+
+            var mapsterInstance = new Mapper();
+
+            var query = context.Students.Where(s => s.ID == 1);
+
+            async Task<StudentDto> FirstExecute() =>
+                await mapsterInstance.From(query)
+                    .ProjectToType<StudentDto>()
+                    .FirstOrDefaultAsync();
+
+            await Should.NotThrowAsync(async () =>
+            {
+                var first = await FirstExecute();
+
+                first.ShouldNotBeNull();
+                first.ID.ShouldBe(1);
+                first.LastName.ShouldBe("Alexander");
+            });
         }
 
         [TestMethod]

--- a/src/Mapster.EFCore/MapsterQueryable.cs
+++ b/src/Mapster.EFCore/MapsterQueryable.cs
@@ -82,9 +82,19 @@ namespace Mapster.EFCore
         {
             var enumerable = ((IAsyncQueryProvider)_provider).ExecuteAsync<TResult>(expression, cancellationToken);
             var enumerableType = typeof(TResult);
+            if (!IsAsyncEnumerableType(enumerableType))
+            {
+                return enumerable;
+            }
             var elementType = enumerableType.GetGenericArguments()[0];
             var wrapType = typeof(MapsterAsyncEnumerable<>).MakeGenericType(elementType);
             return (TResult) Activator.CreateInstance(wrapType, enumerable, _builder);
+        }
+
+        private static bool IsAsyncEnumerableType(Type type)
+        {
+            return type.GetInterfaces()
+                .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>));
         }
 
         public IAsyncEnumerable<TResult> ExecuteEnumerableAsync<TResult>(Expression expression, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Fixes: https://github.com/MapsterMapper/Mapster/issues/820
Fixes: https://github.com/MapsterMapper/Mapster/issues/566 (was closed due to a workaround)

Description:
The issue occurs because the code always attempts to wrap the result in `MapsterAsyncEnumerable`, even when the type does not implement `IAsyncEnumerable`. This fix ensures wrapping only happens if the type actually implements `IAsyncEnumerable`, which prevents the `MissingMethodException` to throw.