### PR TITLE
Disabled NullableEnumFix #643  from MapToProjection cases

### DIFF
--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -479,7 +479,12 @@ namespace Mapster.Adapters
         }
         internal Expression CreateAdaptExpression(Expression source, Type destinationType, CompileArgument arg, MemberMapping? mapping, Expression? destination = null)
         {
-            var _source = source.NullableEnumExtractor(); // Extraction Nullable Enum
+            Expression _source;
+
+            if (arg.MapType != MapType.Projection)
+                _source = source.NullableEnumExtractor(); // Extraction Nullable Enum
+            else
+                _source = source;
 
             if (_source.Type == destinationType && arg.MapType == MapType.Projection)
                 return _source;


### PR DESCRIPTION
Reason:
-NullReferenceException  when source null

Need CreateDynamicMapInvokeExpressionBody() improvement: 
 - need Expression p1 null check and and the handler for such a case