### PR TITLE
Update to  fix #811

### DIFF
--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -227,7 +227,8 @@ namespace Mapster.Adapters
                 else
                 {
 
-                    if (member.Getter.CanBeNull() && member.Ignore.Condition == null)
+                    if (member.Getter.CanBeNull() && member.DestinationMember.Type.IsAbstractOrNotPublicCtor()
+                        && member.Ignore.Condition == null)
                     {
                         var compareNull = Expression.Equal(member.Getter, Expression.Constant(null, member.Getter.Type));
                         getter = Expression.Condition(ExpressionEx.Not(compareNull),

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -429,5 +429,16 @@ namespace Mapster
 
             return false;
         }
+
+        public static bool IsAbstractOrNotPublicCtor(this Type type)
+        {
+            if(type.IsAbstract)
+                return true;
+
+            if (type.GetConstructors().All(x => !x.IsPublic))
+                return true;
+                        
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Now check is generated if the destination type is abstract or does not have a public constructor.