### PR TITLE
Fix Race Condition between Configuration and Adapt()

### DIFF
--- a/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
+++ b/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
@@ -39,6 +39,12 @@ namespace Mapster.Tests
 
             var simplePoco = new WhenAddingCustomMappings.SimplePoco {Id = Guid.NewGuid(), Name = "TestName"};
 
+            //first state (i = 0) Must be configured
+            TypeAdapterConfig<WhenAddingCustomMappings.SimplePoco, WeirdPoco>.NewConfig()
+                               .Map(dest => dest.IHaveADifferentId, src => src.Id)
+                               .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
+                               .Ignore(dest => dest.Children);
+
             var exception = Should.Throw<AggregateException>(() =>
             {
                 for (int i = 0; i < 100; i++)
@@ -65,6 +71,12 @@ namespace Mapster.Tests
         {
             TypeAdapterConfig.GlobalSettings.RequireExplicitMapping = true;
             TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = true;
+
+            //first state (i = 0) Must be configured
+            TypeAdapterConfig<WhenAddingCustomMappings.SimplePoco, WeirdPoco>.NewConfig()
+                               .Map(dest => dest.IHaveADifferentId, src => src.Id)
+                               .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
+                               .Ignore(dest => dest.Children);
 
             var simplePoco = new WhenAddingCustomMappings.SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
 

--- a/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
+++ b/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
@@ -15,6 +15,7 @@ namespace Mapster.Tests
         {
             TypeAdapterConfig.GlobalSettings.RequireExplicitMapping = false;
             TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = false;
+            TypeAdapterConfig.GlobalSettings.IsConcurrencyEnvironment = false;
         }
 
 
@@ -111,10 +112,11 @@ namespace Mapster.Tests
             var simplePoco = new WhenAddingCustomMappings.SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
 
             //first state (i = 0) Must be configured
-            TypeAdapterConfig<WhenAddingCustomMappings.SimplePoco, WeirdPoco>.NewConfig()
+            TypeAdapterConfigConcurrency<WhenAddingCustomMappings.SimplePoco, WeirdPoco>.NewConfig()
                                .Map(dest => dest.IHaveADifferentId, src => src.Id)
                                .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
-                               .Ignore(dest => dest.Children);
+                               .Ignore(dest => dest.Children)
+                               .FinalizeConfig();
 
            
             for (int i = 0; i < 100; i++)
@@ -122,10 +124,11 @@ namespace Mapster.Tests
                 Parallel.Invoke(
                     () =>
                     {
-                        TypeAdapterConfig<WhenAddingCustomMappings.SimplePoco, WeirdPoco>.NewConfig()
+                        TypeAdapterConfigConcurrency<WhenAddingCustomMappings.SimplePoco, WeirdPoco>.NewConfig()
                             .Map(dest => dest.IHaveADifferentId, src => src.Id)
                             .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
-                            .Ignore(dest => dest.Children);
+                            .Ignore(dest => dest.Children)
+                            .FinalizeConfig();
                     },
                     () => { TypeAdapter.Adapt<WeirdPoco>(simplePoco); }
                     );
@@ -150,7 +153,7 @@ namespace Mapster.Tests
                 Parallel.Invoke(
                     () =>
                     {
-                        TypeAdapterConfig.GlobalSettings.Scan(Assembly.GetExecutingAssembly());
+                        TypeAdapterConfig.GlobalSettings.ScanConcurrency(Assembly.GetExecutingAssembly());
                     },
                     () => { TypeAdapter.Adapt<WeirdPoco>(simplePoco); }
                     );

--- a/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
+++ b/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
@@ -106,7 +106,7 @@ namespace Mapster.Tests
         [TestMethod]
         public void Race_Condition_Working()
         {
-            TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = true;
+            TypeAdapterConfig.GlobalSettings.RequireExplicitMapping = true;
             TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = true;
 
             var simplePoco = new WhenAddingCustomMappings.SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
@@ -139,7 +139,7 @@ namespace Mapster.Tests
         [TestMethod]
         public void Scan_Race_Condition_Working()
         {
-            TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = true;
+            TypeAdapterConfig.GlobalSettings.RequireExplicitMapping = true;
             TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = true;
 
             var simplePoco = new WhenAddingCustomMappings.SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };

--- a/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
+++ b/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
 
 namespace Mapster.Tests
 {
@@ -101,11 +102,77 @@ namespace Mapster.Tests
             TypeAdapter.Adapt<WhenAddingCustomMappings.SimplePoco, WeirdPoco>(simplePoco);
         }
 
+        [TestMethod]
+        public void Race_Condition_Working()
+        {
+            TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = true;
+            TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = true;
 
+            var simplePoco = new WhenAddingCustomMappings.SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
+
+            //first state (i = 0) Must be configured
+            TypeAdapterConfig<WhenAddingCustomMappings.SimplePoco, WeirdPoco>.NewConfig()
+                               .Map(dest => dest.IHaveADifferentId, src => src.Id)
+                               .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
+                               .Ignore(dest => dest.Children);
+
+           
+            for (int i = 0; i < 100; i++)
+            {
+                Parallel.Invoke(
+                    () =>
+                    {
+                        TypeAdapterConfig<WhenAddingCustomMappings.SimplePoco, WeirdPoco>.NewConfig()
+                            .Map(dest => dest.IHaveADifferentId, src => src.Id)
+                            .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
+                            .Ignore(dest => dest.Children);
+                    },
+                    () => { TypeAdapter.Adapt<WeirdPoco>(simplePoco); }
+                    );
+            }
+         
+        }
+
+        [TestMethod]
+        public void Scan_Race_Condition_Working()
+        {
+            TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = true;
+            TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = true;
+
+            var simplePoco = new WhenAddingCustomMappings.SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
+
+            //first state (i = 0) Must be configured
+            TypeAdapterConfig.GlobalSettings.Scan(Assembly.GetExecutingAssembly());
+
+
+            for (int i = 0; i < 100; i++)
+            {
+                Parallel.Invoke(
+                    () =>
+                    {
+                        TypeAdapterConfig.GlobalSettings.Scan(Assembly.GetExecutingAssembly());
+                    },
+                    () => { TypeAdapter.Adapt<WeirdPoco>(simplePoco); }
+                    );
+            }
+
+        }
     }
 
 
     #region TestClasses
+
+    public class RegData : IRegister
+    {
+        public void Register(TypeAdapterConfig config)
+        {
+            config.NewConfig<WhenAddingCustomMappings.SimplePoco, WeirdPoco>()
+            .Map(dest => dest.IHaveADifferentId, src => src.Id)
+            .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
+            .Ignore(dest => dest.Children);
+
+        }
+    }
 
     public class SimplePoco
     {

--- a/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
+++ b/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
@@ -15,7 +15,6 @@ namespace Mapster.Tests
         {
             TypeAdapterConfig.GlobalSettings.RequireExplicitMapping = false;
             TypeAdapterConfig.GlobalSettings.RequireDestinationMemberSource = false;
-            TypeAdapterConfig.GlobalSettings.IsConcurrencyEnvironment = false;
         }
 
 

--- a/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
+++ b/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs
@@ -112,28 +112,35 @@ namespace Mapster.Tests
             var simplePoco = new WhenAddingCustomMappings.SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
 
             //first state (i = 0) Must be configured
-            TypeAdapterConfigConcurrency<WhenAddingCustomMappings.SimplePoco, WeirdPoco>.NewConfig()
-                               .Map(dest => dest.IHaveADifferentId, src => src.Id)
-                               .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
-                               .Ignore(dest => dest.Children)
-                               .FinalizeConfig();
+            TypeAdapterConfigConcurrency<WhenAddingCustomMappings.SimplePoco, WeirdPoco>
+                .NewConfig(cfg =>
+                {
+                    cfg
+                        .Map(dest => dest.IHaveADifferentId, src => src.Id)
+                        .Map(dest => dest.IHaveADifferentId, src => src.Id)
+                        .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
+                        .Ignore(dest => dest.Children);
+                });
 
-           
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 1000; i++)
             {
                 Parallel.Invoke(
                     () =>
                     {
-                        TypeAdapterConfigConcurrency<WhenAddingCustomMappings.SimplePoco, WeirdPoco>.NewConfig()
-                            .Map(dest => dest.IHaveADifferentId, src => src.Id)
-                            .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
-                            .Ignore(dest => dest.Children)
-                            .FinalizeConfig();
+                        TypeAdapterConfigConcurrency<WhenAddingCustomMappings.SimplePoco, WeirdPoco>
+                            .NewConfig(cfg =>
+                            {
+                                cfg
+                                    .Map(dest => dest.IHaveADifferentId, src => src.Id)
+                                    .Map(dest => dest.IHaveADifferentId, src => src.Id)
+                                    .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
+                                    .Ignore(dest => dest.Children);
+                            });
                     },
                     () => { TypeAdapter.Adapt<WeirdPoco>(simplePoco); }
                     );
             }
-         
+
         }
 
         [TestMethod]
@@ -148,7 +155,7 @@ namespace Mapster.Tests
             TypeAdapterConfig.GlobalSettings.Scan(Assembly.GetExecutingAssembly());
 
 
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 1000; i++)
             {
                 Parallel.Invoke(
                     () =>

--- a/src/Mapster.Tests/WhenScanningForRegisters.cs
+++ b/src/Mapster.Tests/WhenScanningForRegisters.cs
@@ -16,7 +16,7 @@ namespace Mapster.Tests
         {
             var config = new TypeAdapterConfig();
             IList<IRegister> registers = config.Scan(Assembly.GetExecutingAssembly());
-            registers.Count.ShouldBe(2);
+            registers.Count.ShouldBe(3);
 
             var typeTuples = config.RuleMap.Keys.ToList();
 

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -1,18 +1,32 @@
-﻿using System;
+﻿using Mapster.Adapters;
+using Mapster.Models;
+using Mapster.Utils;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using Mapster.Adapters;
-using Mapster.Models;
-using Mapster.Utils;
+using System.Threading;
 
 namespace Mapster
 {
     public class TypeAdapterConfig
     {
+        #region ConcurrencyMod
+
+        [AdaptIgnore]
+        public AutoResetEvent ConfigureSync { get; set; }
+
+        [AdaptIgnore]
+        public AutoResetEvent ApplySync { get; set; }
+
+        public bool IsConcurrencyEnvironment { get; set; }
+        public bool IsScanConcurrency { get; set; }
+
+        #endregion ConcurrencyMod
+
         public static List<TypeAdapterRule> RulesTemplate { get; } = CreateRuleTemplate();
         public static TypeAdapterConfig GlobalSettings { get; } = new TypeAdapterConfig();
 
@@ -95,6 +109,9 @@ namespace Mapster
 
         public TypeAdapterConfig()
         {
+            ConfigureSync = new(true);
+            ApplySync = new(true);
+
             Rules = RulesTemplate.ToList();
             var settings = new TypeAdapterSettings();
             Default = new TypeAdapterSetter(settings, this);
@@ -148,6 +165,9 @@ namespace Mapster
 		/// <returns></returns>
 		public TypeAdapterSetter<TSource, TDestination> NewConfig<TSource, TDestination>()
         {
+            if (IsConcurrencyEnvironment && !IsScanConcurrency)
+                ConfigureSync.WaitOne(-1, false);
+
             Remove(typeof(TSource), typeof(TDestination));
             return ForType<TSource, TDestination>();
         }
@@ -161,6 +181,9 @@ namespace Mapster
 		/// <returns></returns>
 		public TypeAdapterSetter NewConfig(Type sourceType, Type destinationType)
         {
+            if (IsConcurrencyEnvironment && !IsScanConcurrency)
+                ConfigureSync.WaitOne(-1, false);
+
             Remove(sourceType, destinationType);
             return ForType(sourceType, destinationType);
         }
@@ -385,6 +408,12 @@ namespace Mapster
 
         public LambdaExpression CreateMapExpression(TypeTuple tuple, MapType mapType)
         {
+            if (IsConcurrencyEnvironment)
+                ConfigureSync.WaitOne(-1);
+
+            if (IsScanConcurrency)
+                ApplySync.WaitOne(-1);
+
             var context = new CompileContext(this);
             context.Running.Add(tuple);
             Action<TypeAdapterConfig>? fork = null;
@@ -403,6 +432,9 @@ namespace Mapster
             }
             finally
             {
+                ApplySync.Set();
+                ConfigureSync.Set();
+
                 if (fork != null)
                     context.Configs.Pop();
                 context.Running.Remove(tuple);
@@ -738,12 +770,29 @@ namespace Mapster
             return registers;
         }
 
+        public IList<IRegister> ScanConcurrency(params Assembly[] assemblies)
+        {
 
-		/// <summary>
-		/// Applies type mappings.
-		/// </summary>
-		/// <param name="registers">collection of IRegister interface to apply mapping.</param>
-		public void Apply(IEnumerable<Lazy<IRegister>> registers)
+            IsConcurrencyEnvironment = true;
+            ConfigureSync.WaitOne(-1);
+            IsScanConcurrency = true;
+
+            try
+            {
+                return Scan(assemblies);
+            }
+            finally
+            {
+                ConfigureSync.Set();
+                IsConcurrencyEnvironment = false;
+            }
+        }
+
+        /// <summary>
+        /// Applies type mappings.
+        /// </summary>
+        /// <param name="registers">collection of IRegister interface to apply mapping.</param>
+        public void Apply(IEnumerable<Lazy<IRegister>> registers)
         {
             Apply(registers.Select(register => register.Value));
         }
@@ -755,10 +804,14 @@ namespace Mapster
 		/// <param name="registers">collection of IRegister interface to apply mapping.</param>
 		public void Apply(IEnumerable<IRegister> registers)
         {
+            ApplySync.WaitOne(-1, false);
+
             foreach (IRegister register in registers)
             {
                 register.Register(this);
             }
+
+            ApplySync.Set();
         }
 
 
@@ -878,6 +931,39 @@ namespace Mapster
 		/// Clears the type mapping configuration for the specified source and destination types.
 		/// </summary>
 		public static void Clear()
+        {
+            TypeAdapterConfig.GlobalSettings.Remove(typeof(TSource), typeof(TDestination));
+        }
+    }
+
+    public static class TypeAdapterConfigConcurrency<TSource, TDestination>
+    {
+        /// <summary>
+        ///  Creates a new configuration for mapping between the source and destination types.
+        /// </summary>
+        /// <returns></returns>
+        public static TypeAdapterSetter<TSource, TDestination> NewConfig()
+        {
+            TypeAdapterConfig.GlobalSettings.IsConcurrencyEnvironment = true;
+            return TypeAdapterConfig.GlobalSettings.NewConfig<TSource, TDestination>();
+        }
+
+
+        /// <summary>
+        /// Creates a configuration for mapping between the source and destination types.
+        /// </summary>
+        /// <returns></returns>
+        public static TypeAdapterSetter<TSource, TDestination> ForType()
+        {
+            TypeAdapterConfig.GlobalSettings.IsConcurrencyEnvironment = true;
+            return TypeAdapterConfig.GlobalSettings.ForType<TSource, TDestination>();
+        }
+
+
+        /// <summary>
+        /// Clears the type mapping configuration for the specified source and destination types.
+        /// </summary>
+        public static void Clear()
         {
             TypeAdapterConfig.GlobalSettings.Remove(typeof(TSource), typeof(TDestination));
         }

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -165,9 +165,6 @@ namespace Mapster
 		/// <returns></returns>
 		public TypeAdapterSetter<TSource, TDestination> NewConfig<TSource, TDestination>()
         {
-            if (IsConcurrencyEnvironment && !IsScanConcurrency)
-                ConfigureSync.WaitOne(-1, false);
-
             Remove(typeof(TSource), typeof(TDestination));
             return ForType<TSource, TDestination>();
         }
@@ -181,9 +178,6 @@ namespace Mapster
 		/// <returns></returns>
 		public TypeAdapterSetter NewConfig(Type sourceType, Type destinationType)
         {
-            if (IsConcurrencyEnvironment && !IsScanConcurrency)
-                ConfigureSync.WaitOne(-1, false);
-
             Remove(sourceType, destinationType);
             return ForType(sourceType, destinationType);
         }
@@ -345,8 +339,7 @@ namespace Mapster
         }
         internal Delegate GetMapFunction(Type sourceType, Type destinationType)
         {
-            if (IsConcurrencyEnvironment)
-                ConfigureSync.WaitOne(-1);
+            ConfigureSync.WaitOne(-1);
 
             if (IsScanConcurrency)
                 ApplySync.WaitOne(-1);
@@ -371,8 +364,7 @@ namespace Mapster
         }
         internal Delegate GetMapToTargetFunction(Type sourceType, Type destinationType)
         {
-            if (IsConcurrencyEnvironment)
-                ConfigureSync.WaitOne(-1);
+            ConfigureSync.WaitOne(-1);
 
             if (IsScanConcurrency)
                 ApplySync.WaitOne(-1);
@@ -401,8 +393,7 @@ namespace Mapster
         }
         internal MethodCallExpression GetProjectionCallExpression(Type sourceType, Type destinationType)
         {
-            if (IsConcurrencyEnvironment)
-                ConfigureSync.WaitOne(-1);
+            ConfigureSync.WaitOne(-1);
 
             if (IsScanConcurrency)
                 ApplySync.WaitOne(-1);
@@ -424,8 +415,7 @@ namespace Mapster
         private readonly ConcurrentDictionary<TypeTuple, Delegate> _dynamicMapDict = new ConcurrentDictionary<TypeTuple, Delegate>();
         public Func<object, TDestination> GetDynamicMapFunction<TDestination>(Type sourceType)
         {
-            if (IsConcurrencyEnvironment)
-                ConfigureSync.WaitOne(-1);
+            ConfigureSync.WaitOne(-1);
 
             if (IsScanConcurrency)
                 ApplySync.WaitOne(-1);
@@ -986,34 +976,21 @@ namespace Mapster
 
     public static class TypeAdapterConfigConcurrency<TSource, TDestination>
     {
-        /// <summary>
-        ///  Creates a new configuration for mapping between the source and destination types.
-        /// </summary>
-        /// <returns></returns>
-        public static TypeAdapterSetter<TSource, TDestination> NewConfig()
+        public static void NewConfig(Action<TypeAdapterSetter<TSource, TDestination>> cfg)
         {
-            TypeAdapterConfig.GlobalSettings.IsConcurrencyEnvironment = true;
-            return TypeAdapterConfig.GlobalSettings.NewConfig<TSource, TDestination>();
-        }
+            var config = TypeAdapterConfig.GlobalSettings;
 
+            config.IsConcurrencyEnvironment = true;
+            config.ConfigureSync.WaitOne(-1, false);
 
-        /// <summary>
-        /// Creates a configuration for mapping between the source and destination types.
-        /// </summary>
-        /// <returns></returns>
-        public static TypeAdapterSetter<TSource, TDestination> ForType()
-        {
-            TypeAdapterConfig.GlobalSettings.IsConcurrencyEnvironment = true;
-            return TypeAdapterConfig.GlobalSettings.ForType<TSource, TDestination>();
-        }
-
-
-        /// <summary>
-        /// Clears the type mapping configuration for the specified source and destination types.
-        /// </summary>
-        public static void Clear()
-        {
-            TypeAdapterConfig.GlobalSettings.Remove(typeof(TSource), typeof(TDestination));
+            try
+            {
+                cfg.Invoke(TypeAdapterConfig<TSource, TDestination>.NewConfig());
+            }
+            finally
+            {
+                config.ConfigureSync.Set();
+            }
         }
     }
 }

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -337,10 +337,10 @@ namespace Mapster
         }
         internal Delegate GetMapFunction(Type sourceType, Type destinationType)
         {
-            ConfigureSync.WaitOne(-1);
+            ConfigureSync.WaitOne();
 
             if (IsScanConcurrency)
-                ApplySync.WaitOne(-1);
+                ApplySync.WaitOne();
             try
             {
                 var key = new TypeTuple(sourceType, destinationType);
@@ -362,10 +362,10 @@ namespace Mapster
         }
         internal Delegate GetMapToTargetFunction(Type sourceType, Type destinationType)
         {
-            ConfigureSync.WaitOne(-1);
+            ConfigureSync.WaitOne();
 
             if (IsScanConcurrency)
-                ApplySync.WaitOne(-1);
+                ApplySync.WaitOne();
 
             try
             {
@@ -391,10 +391,10 @@ namespace Mapster
         }
         internal MethodCallExpression GetProjectionCallExpression(Type sourceType, Type destinationType)
         {
-            ConfigureSync.WaitOne(-1);
+            ConfigureSync.WaitOne();
 
             if (IsScanConcurrency)
-                ApplySync.WaitOne(-1);
+                ApplySync.WaitOne();
 
             try
             {
@@ -413,7 +413,7 @@ namespace Mapster
         private readonly ConcurrentDictionary<TypeTuple, Delegate> _dynamicMapDict = new ConcurrentDictionary<TypeTuple, Delegate>();
         public Func<object, TDestination> GetDynamicMapFunction<TDestination>(Type sourceType)
         {
-            ConfigureSync.WaitOne(-1);
+            ConfigureSync.WaitOne();
 
             if (IsScanConcurrency)
                 ApplySync.WaitOne(-1);
@@ -808,7 +808,7 @@ namespace Mapster
 
         public IList<IRegister> ScanConcurrency(params Assembly[] assemblies)
         {
-            ConfigureSync.WaitOne(-1);
+            ConfigureSync.WaitOne();
             IsScanConcurrency = true;
 
             try
@@ -837,7 +837,7 @@ namespace Mapster
 		/// <param name="registers">collection of IRegister interface to apply mapping.</param>
 		public void Apply(IEnumerable<IRegister> registers)
         {
-            ApplySync.WaitOne(-1, false);
+            ApplySync.WaitOne();
 
             foreach (IRegister register in registers)
             {
@@ -975,7 +975,7 @@ namespace Mapster
         {
             var config = TypeAdapterConfig.GlobalSettings;
 
-            config.ConfigureSync.WaitOne(-1, false);
+            config.ConfigureSync.WaitOne();
 
             try
             {

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -17,13 +17,11 @@ namespace Mapster
         #region ConcurrencyMod
 
         [AdaptIgnore]
-        public AutoResetEvent ConfigureSync { get; set; }
+        internal AutoResetEvent ConfigureSync { get; set; }
 
         [AdaptIgnore]
-        public AutoResetEvent ApplySync { get; set; }
-
-        public bool IsConcurrencyEnvironment { get; set; }
-        public bool IsScanConcurrency { get; set; }
+        internal AutoResetEvent ApplySync { get; set; }
+        internal bool IsScanConcurrency { get; set; }
 
         #endregion ConcurrencyMod
 
@@ -810,8 +808,6 @@ namespace Mapster
 
         public IList<IRegister> ScanConcurrency(params Assembly[] assemblies)
         {
-
-            IsConcurrencyEnvironment = true;
             ConfigureSync.WaitOne(-1);
             IsScanConcurrency = true;
 
@@ -822,7 +818,6 @@ namespace Mapster
             finally
             {
                 ConfigureSync.Set();
-                IsConcurrencyEnvironment = false;
             }
         }
 
@@ -980,7 +975,6 @@ namespace Mapster
         {
             var config = TypeAdapterConfig.GlobalSettings;
 
-            config.IsConcurrencyEnvironment = true;
             config.ConfigureSync.WaitOne(-1, false);
 
             try

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -345,10 +345,23 @@ namespace Mapster
         }
         internal Delegate GetMapFunction(Type sourceType, Type destinationType)
         {
-            var key = new TypeTuple(sourceType, destinationType);
-            if (!_mapDict.TryGetValue(key, out var del))
-                del = AddToHash(_mapDict, key, tuple => Compiler(CreateMapExpression(tuple, MapType.Map)));
-            return del;
+            if (IsConcurrencyEnvironment)
+                ConfigureSync.WaitOne(-1);
+
+            if (IsScanConcurrency)
+                ApplySync.WaitOne(-1);
+            try
+            {
+                var key = new TypeTuple(sourceType, destinationType);
+                if (!_mapDict.TryGetValue(key, out var del))
+                    del = AddToHash(_mapDict, key, tuple => Compiler(CreateMapExpression(tuple, MapType.Map)));
+                return del;
+            }
+            finally
+            {
+                ApplySync.Set();
+                ConfigureSync.Set();
+            }
         }
 
         private readonly ConcurrentDictionary<TypeTuple, Delegate> _mapToTargetDict = new ConcurrentDictionary<TypeTuple, Delegate>();
@@ -358,10 +371,25 @@ namespace Mapster
         }
         internal Delegate GetMapToTargetFunction(Type sourceType, Type destinationType)
         {
-            var key = new TypeTuple(sourceType, destinationType);
-            if (!_mapToTargetDict.TryGetValue(key, out var del))
-                del = AddToHash(_mapToTargetDict, key, tuple => Compiler(CreateMapExpression(tuple, MapType.MapToTarget)));
-            return del;
+            if (IsConcurrencyEnvironment)
+                ConfigureSync.WaitOne(-1);
+
+            if (IsScanConcurrency)
+                ApplySync.WaitOne(-1);
+
+            try
+            {
+                var key = new TypeTuple(sourceType, destinationType);
+                if (!_mapToTargetDict.TryGetValue(key, out var del))
+                    del = AddToHash(_mapToTargetDict, key, tuple => Compiler(CreateMapExpression(tuple, MapType.MapToTarget)));
+                return del;
+            }
+            finally
+            {
+                ApplySync.Set();
+                ConfigureSync.Set();
+            }
+            
         }
 
         private readonly ConcurrentDictionary<TypeTuple, MethodCallExpression> _projectionDict = new ConcurrentDictionary<TypeTuple, MethodCallExpression>();
@@ -373,19 +401,47 @@ namespace Mapster
         }
         internal MethodCallExpression GetProjectionCallExpression(Type sourceType, Type destinationType)
         {
-            var key = new TypeTuple(sourceType, destinationType);
-            if (!_projectionDict.TryGetValue(key, out var del))
-                del = AddToHash(_projectionDict, key, CreateProjectionCallExpression);
-            return del;
+            if (IsConcurrencyEnvironment)
+                ConfigureSync.WaitOne(-1);
+
+            if (IsScanConcurrency)
+                ApplySync.WaitOne(-1);
+
+            try
+            {
+                var key = new TypeTuple(sourceType, destinationType);
+                if (!_projectionDict.TryGetValue(key, out var del))
+                    del = AddToHash(_projectionDict, key, CreateProjectionCallExpression);
+                return del;
+            }
+            finally
+            {
+                ApplySync.Set();
+                ConfigureSync.Set();
+            }
         }
 
         private readonly ConcurrentDictionary<TypeTuple, Delegate> _dynamicMapDict = new ConcurrentDictionary<TypeTuple, Delegate>();
         public Func<object, TDestination> GetDynamicMapFunction<TDestination>(Type sourceType)
         {
-            var key = new TypeTuple(sourceType, typeof(TDestination));
-            if (!_dynamicMapDict.TryGetValue(key, out var del))
-                del = AddToHash(_dynamicMapDict, key, tuple => Compiler(CreateDynamicMapExpression(tuple)));
-            return (Func<object, TDestination>)del;
+            if (IsConcurrencyEnvironment)
+                ConfigureSync.WaitOne(-1);
+
+            if (IsScanConcurrency)
+                ApplySync.WaitOne(-1);
+
+            try
+            {
+                var key = new TypeTuple(sourceType, typeof(TDestination));
+                if (!_dynamicMapDict.TryGetValue(key, out var del))
+                    del = AddToHash(_dynamicMapDict, key, tuple => Compiler(CreateDynamicMapExpression(tuple)));
+                return (Func<object, TDestination>)del;
+            }
+            finally
+            {
+                ApplySync.Set();
+                ConfigureSync.Set();
+            }
         }
 
         private Expression CreateSelfExpression()
@@ -408,12 +464,6 @@ namespace Mapster
 
         public LambdaExpression CreateMapExpression(TypeTuple tuple, MapType mapType)
         {
-            if (IsConcurrencyEnvironment)
-                ConfigureSync.WaitOne(-1);
-
-            if (IsScanConcurrency)
-                ApplySync.WaitOne(-1);
-
             var context = new CompileContext(this);
             context.Running.Add(tuple);
             Action<TypeAdapterConfig>? fork = null;
@@ -432,9 +482,7 @@ namespace Mapster
             }
             finally
             {
-                ApplySync.Set();
-                ConfigureSync.Set();
-
+               
                 if (fork != null)
                     context.Configs.Pop();
                 context.Running.Remove(tuple);

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -19,10 +19,6 @@ namespace Mapster
         [AdaptIgnore]
         internal AutoResetEvent ConfigureSync { get; set; }
 
-        [AdaptIgnore]
-        internal AutoResetEvent ApplySync { get; set; }
-        internal bool IsScanConcurrency { get; set; }
-
         #endregion ConcurrencyMod
 
         public static List<TypeAdapterRule> RulesTemplate { get; } = CreateRuleTemplate();
@@ -108,8 +104,7 @@ namespace Mapster
         public TypeAdapterConfig()
         {
             ConfigureSync = new(true);
-            ApplySync = new(true);
-
+           
             Rules = RulesTemplate.ToList();
             var settings = new TypeAdapterSettings();
             Default = new TypeAdapterSetter(settings, this);
@@ -339,8 +334,6 @@ namespace Mapster
         {
             ConfigureSync.WaitOne();
 
-            if (IsScanConcurrency)
-                ApplySync.WaitOne();
             try
             {
                 var key = new TypeTuple(sourceType, destinationType);
@@ -350,7 +343,6 @@ namespace Mapster
             }
             finally
             {
-                ApplySync.Set();
                 ConfigureSync.Set();
             }
         }
@@ -364,9 +356,6 @@ namespace Mapster
         {
             ConfigureSync.WaitOne();
 
-            if (IsScanConcurrency)
-                ApplySync.WaitOne();
-
             try
             {
                 var key = new TypeTuple(sourceType, destinationType);
@@ -376,7 +365,6 @@ namespace Mapster
             }
             finally
             {
-                ApplySync.Set();
                 ConfigureSync.Set();
             }
             
@@ -393,9 +381,6 @@ namespace Mapster
         {
             ConfigureSync.WaitOne();
 
-            if (IsScanConcurrency)
-                ApplySync.WaitOne();
-
             try
             {
                 var key = new TypeTuple(sourceType, destinationType);
@@ -405,7 +390,6 @@ namespace Mapster
             }
             finally
             {
-                ApplySync.Set();
                 ConfigureSync.Set();
             }
         }
@@ -414,9 +398,6 @@ namespace Mapster
         public Func<object, TDestination> GetDynamicMapFunction<TDestination>(Type sourceType)
         {
             ConfigureSync.WaitOne();
-
-            if (IsScanConcurrency)
-                ApplySync.WaitOne(-1);
 
             try
             {
@@ -427,7 +408,6 @@ namespace Mapster
             }
             finally
             {
-                ApplySync.Set();
                 ConfigureSync.Set();
             }
         }
@@ -809,8 +789,7 @@ namespace Mapster
         public IList<IRegister> ScanConcurrency(params Assembly[] assemblies)
         {
             ConfigureSync.WaitOne();
-            IsScanConcurrency = true;
-
+           
             try
             {
                 return Scan(assemblies);
@@ -837,14 +816,10 @@ namespace Mapster
 		/// <param name="registers">collection of IRegister interface to apply mapping.</param>
 		public void Apply(IEnumerable<IRegister> registers)
         {
-            ApplySync.WaitOne();
-
             foreach (IRegister register in registers)
             {
                 register.Register(this);
             }
-
-            ApplySync.Set();
         }
 
 

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -31,6 +31,23 @@ namespace Mapster
                 throw new InvalidOperationException("TypeAdapter.Adapt was already called, please clone or create new TypeAdapterConfig.");
         }
 
+        public static TSetter FinalizeConfig<TSetter>(this TSetter setter) where TSetter : TypeAdapterSetter
+        {
+            try
+            {
+                setter.CheckCompiled();
+                return setter;
+            }
+            finally
+            {
+                if (setter.Config.IsConcurrencyEnvironment)
+                {
+                    setter.Config.ConfigureSync.Set();
+                }
+
+            }
+        }
+
         public static TSetter AddDestinationTransform<TSetter, TDestinationMember>(this TSetter setter, Expression<Func<TDestinationMember, TDestinationMember>> transform) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -31,23 +31,6 @@ namespace Mapster
                 throw new InvalidOperationException("TypeAdapter.Adapt was already called, please clone or create new TypeAdapterConfig.");
         }
 
-        public static TSetter FinalizeConfig<TSetter>(this TSetter setter) where TSetter : TypeAdapterSetter
-        {
-            try
-            {
-                setter.CheckCompiled();
-                return setter;
-            }
-            finally
-            {
-                if (setter.Config.IsConcurrencyEnvironment)
-                {
-                    setter.Config.ConfigureSync.Set();
-                }
-
-            }
-        }
-
         public static TSetter AddDestinationTransform<TSetter, TDestinationMember>(this TSetter setter, Expression<Func<TDestinationMember, TDestinationMember>> transform) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();


### PR DESCRIPTION
Based on[ these tests](https://github.com/MapsterMapper/Mapster/blob/master/src/Mapster.Tests/WhenRegisteringAndMappingRace.cs) and #86, #138


Depending on the speed and order of execution (configuration and Adapt()), one of the following situations can occur:
1) Incomplete configuration (the main cause of errors in the tests mentioned at the beginning);
2) "Incomplete cleanup" - Exception: "TypeAdapter.Adapt was already called, please clone or create a new TypeAdapterConfig."
3) Exception to collection modification during enumeration.

Additional problem:
The current configuration design does not provide information about configuration completion.

add This PR 

1. Thread safety creating a new configuration:
```
 TypeAdapterConfigConcurrency<WhenAddingCustomMappings.SimplePoco, WeirdPoco>
                .NewConfig(cfg =>
                {
                    cfg
                        .Map(dest => dest.IHaveADifferentId, src => src.Id)
                        .Map(dest => dest.IHaveADifferentId, src => src.Id)
                        .Map(dest => dest.MyNamePropertyIsDifferent, src => src.Name)
                        .Ignore(dest => dest.Children);
                });

```

2.  Thread safety loading configurations:

`TypeAdapterConfig.GlobalSettings.ScanConcurrency(Assembly.GetExecutingAssembly());`
