### PR TITLE
fix: IgnoreNullValues regression from MapToTarget cases in #905

### DIFF
--- a/src/Mapster.Tests/WhenPropertyNullablePropagationRegression.cs
+++ b/src/Mapster.Tests/WhenPropertyNullablePropagationRegression.cs
@@ -16,7 +16,6 @@ public class WhenPropertyNullablePropagationRegression
     {
         TypeAdapterConfig<Foo858, Bar858>
           .NewConfig()
-          .IgnoreNullValues(true)
           .Map(dest => dest.Amount, src => src.Amount)
           .Map(dest => dest.InnerAmount, src => src.Inner.Amount);
 
@@ -35,15 +34,9 @@ public class WhenPropertyNullablePropagationRegression
             }
         };
 
-        var updateBar = new Bar858 { Amount = new(10, Currency858.Eur), InnerAmount = new(10, Currency858.Eur) };
-        var snull = new Foo858() { Amount = new(1, Currency858.Usd), Inner = null };
-
         // Act
         var bar = foo.Adapt<Bar858>();
 
-        var str = snull.BuildAdapter().CreateMapToTargetExpression<Bar858>();
-
-        snull.Adapt(updateBar);
         // Assert
         bar.InnerAmount.Amount.ShouldBe(10m);
     }
@@ -103,6 +96,43 @@ public class WhenPropertyNullablePropagationRegression
         bar.Amount.Amount.ShouldBe(2m);
         bar.Amount.Currency.ShouldBe(Currency858.Ron);
     }
+
+    [TestMethod]
+    public void MapToTargetWorkCorrect()
+    {
+        TypeAdapterConfig<Foo858, Bar858>
+          .NewConfig()
+          .IgnoreNullValues(true)
+          .Map(dest => dest.Amount, src => src.Amount)
+          .Map(dest => dest.InnerAmount, src => src.Inner.Amount);
+
+        Foo858 foo = new()
+        {
+            Amount = new(1, Currency858.Usd),
+            Inner = new()
+            {
+                Amount = new(10, Currency858.Eur),
+                Int = 100,
+            }
+        };
+
+        var nullFoo = new Foo858() { Amount = new(2, Currency858.Ron), Inner = new()
+        {
+            Amount = new(20, Currency858.Eur),
+            Int = 100,
+        }
+        };
+
+        // Act
+        var bar = foo.Adapt<Bar858>();
+        nullFoo.Adapt(bar);
+
+        // Assert
+        bar.InnerAmount.Amount.ShouldBe(20m);
+        bar.Amount.Amount.ShouldBe(2m);
+        bar.Amount.Currency.ShouldBe(Currency858.Ron);
+    }
+
 
 }
 

--- a/src/Mapster.Tests/WhenPropertyNullablePropagationRegression.cs
+++ b/src/Mapster.Tests/WhenPropertyNullablePropagationRegression.cs
@@ -12,12 +12,17 @@ public class WhenPropertyNullablePropagationRegression
     /// </summary>
     /// <returns></returns>
     [TestMethod]
-    public async Task NotNullableStructMapToNotNullableCorrect()
+    public void NotNullableStructMapToNotNullableCorrect()
     {
-         TypeAdapterConfig<Foo858, Bar858>
+        TypeAdapterConfig<Foo858, Bar858>
+          .NewConfig()
+          .IgnoreNullValues(true)
+          .Map(dest => dest.Amount, src => src.Amount)
+          .Map(dest => dest.InnerAmount, src => src.Inner.Amount);
+
+        TypeAdapterConfig<Bar858, Bar858>
              .NewConfig()
-             .Map(dest => dest.Amount, src => src.Amount)
-             .Map(dest => dest.InnerAmount, src => src.Inner.Amount);
+             .IgnoreNullValues(true);
 
 
         Foo858 foo = new()
@@ -30,14 +35,21 @@ public class WhenPropertyNullablePropagationRegression
             }
         };
 
+        var updateBar = new Bar858 { Amount = new(10, Currency858.Eur), InnerAmount = new(10, Currency858.Eur) };
+        var snull = new Foo858() { Amount = new(1, Currency858.Usd), Inner = null };
+
         // Act
         var bar = foo.Adapt<Bar858>();
+
+        var str = snull.BuildAdapter().CreateMapToTargetExpression<Bar858>();
+
+        snull.Adapt(updateBar);
         // Assert
         bar.InnerAmount.Amount.ShouldBe(10m);
     }
 
     [TestMethod]
-    public async Task NotNullableStructMapToNullableCorrect()
+    public void NotNullableStructMapToNullableCorrect()
     {
         TypeAdapterConfig<Foo858, Bar858Nullable>
             .NewConfig()
@@ -59,6 +71,37 @@ public class WhenPropertyNullablePropagationRegression
         var bar = foo.Adapt<Bar858Nullable>();
         // Assert
         bar.InnerAmount?.Amount.ShouldBe(10m);
+    }
+
+    [TestMethod]
+    public void IgnoreNullValueWorkCorrect()
+    {
+        TypeAdapterConfig<Foo858, Bar858>
+          .NewConfig()
+          .IgnoreNullValues(true)
+          .Map(dest => dest.Amount, src => src.Amount)
+          .Map(dest => dest.InnerAmount, src => src.Inner.Amount);
+
+        Foo858 foo = new()
+        {
+            Amount = new(1, Currency858.Usd),
+            Inner = new()
+            {
+                Amount = new(10, Currency858.Eur),
+                Int = 100,
+            }
+        };
+
+        var nullFoo = new Foo858() { Amount = new(2, Currency858.Ron), Inner = null };
+
+        // Act
+        var bar = foo.Adapt<Bar858>();
+        nullFoo.Adapt(bar);
+
+        // Assert
+        bar.InnerAmount.Amount.ShouldBe(10m);
+        bar.Amount.Amount.ShouldBe(2m);
+        bar.Amount.Currency.ShouldBe(Currency858.Ron);
     }
 
 }

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -132,7 +132,7 @@ namespace Mapster.Adapters
                 {
                     propertyModel.Getter = arg.MapType == MapType.Projection 
                         ? getter 
-                        : getter.ApplyPropertyNullPropagation(propertyModel);
+                        : getter.ApplyPropertyNullPropagation(propertyModel, arg.MapType);
                     properties.Add(propertyModel);
                 }
                 else

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -132,7 +132,7 @@ namespace Mapster.Adapters
                 {
                     propertyModel.Getter = arg.MapType == MapType.Projection 
                         ? getter 
-                        : getter.ApplyPropertyNullPropagation(propertyModel, arg.MapType);
+                        : getter.ApplyPropertyNullPropagation();
                     properties.Add(propertyModel);
                 }
                 else

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -114,7 +114,17 @@ namespace Mapster.Adapters
                     ? member.DestinationMember.GetExpression(destination)
                     : null;
 
-                var adapt = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member, destMember);
+                Expression adapt;
+
+                // convert ApplyNullable Propagation for NotPrimitive Nullable types
+                if (member.Getter is ConditionalExpression cond && member.Getter.Type.IsNotPrimitiveNullableType()
+                    && !member.DestinationMember.Type.IsNullable())
+                {
+                    var value = CreateAdaptExpression(cond.IfTrue.GetNotPrimitiveNullableValue(), member.DestinationMember.Type, arg, member, destMember);
+                   adapt = Expression.Condition(cond.Test, value, member.DestinationMember.Type.CreateDefault());
+                }
+                else
+                    adapt = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member, destMember);
 
                 if (member.UseDestinationValue
                     && member.DestinationMember.Type.IsMapsterImmutable()
@@ -251,7 +261,17 @@ namespace Mapster.Adapters
                 if (member.DestinationMember.SetterModifier == AccessModifier.None)
                     continue;
 
-                var value = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member);
+                Expression value;
+
+                // convert ApplyNullable Propagation for NotPrimitive Nullable types
+                if (member.Getter is ConditionalExpression cond && member.Getter.Type.IsNotPrimitiveNullableType() 
+                    && !member.DestinationMember.Type.IsNullable())
+                {
+                    var adapt = CreateAdaptExpression(cond.IfTrue.GetNotPrimitiveNullableValue(), member.DestinationMember.Type, arg, member);
+                    value = Expression.Condition(cond.Test, adapt, member.DestinationMember.Type.CreateDefault());
+                }
+                else
+                    value = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member);
 
                 //special null property check for projection
                 //if we don't set null to property, EF will create empty object
@@ -269,19 +289,6 @@ namespace Mapster.Adapters
             }
 
             return Expression.MemberInit(newInstance, lines);
-        }
-
-        protected override Expression TransformSource(Expression source)
-        {
-            if (source.Type.IsNullableType())
-            {
-                var getValueOrDefaultMethod = source.Type.GetMethod("GetValueOrDefault", Type.EmptyTypes);
-                var getValue = Expression.Call(source, getValueOrDefaultMethod);
-
-                return getValue;
-            }
-
-            return source;
         }
     }
 }

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -270,5 +270,18 @@ namespace Mapster.Adapters
 
             return Expression.MemberInit(newInstance, lines);
         }
+
+        protected override Expression TransformSource(Expression source)
+        {
+            if (source.Type.IsNullableType())
+            {
+                var getValueOrDefaultMethod = source.Type.GetMethod("GetValueOrDefault", Type.EmptyTypes);
+                var getValue = Expression.Call(source, getValueOrDefaultMethod);
+
+                return getValue;
+            }
+
+            return source;
+        }
     }
 }

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -407,7 +407,7 @@ namespace Mapster.Utils
 
             return param;
         }
-        public static Expression ApplyPropertyNullPropagation(this Expression getter, MemberMapping property)
+        public static Expression ApplyPropertyNullPropagation(this Expression getter, MemberMapping property, MapType mapType)
         {
             var current = getter;
             var result = getter;
@@ -421,13 +421,27 @@ namespace Mapster.Utils
                     break;
                 if (expr.NodeType == ExpressionType.Parameter && condition != null)
                 {
-                    if (property.DestinationMember.Type.CanBeNull() && !getter.CanBeNull())
+                    if(mapType != MapType.MapToTarget)
                     {
-                        var transform = Expression.Convert(getter, typeof(Nullable<>).MakeGenericType(getter.Type));
-                        return Expression.Condition(condition, transform, transform.Type.CreateDefault());
+                        if (property.DestinationMember.Type.CanBeNull() && !getter.CanBeNull())
+                        {
+                            var transform = Expression.Convert(getter, typeof(Nullable<>).MakeGenericType(getter.Type));
+                            return Expression.Condition(condition, transform, transform.Type.CreateDefault());
+                        }
+                        else
+                            return Expression.Condition(condition, getter, getter.Type.CreateDefault());
                     }
                     else
-                        return Expression.Condition(condition, getter, getter.Type.CreateDefault());
+                    {
+                        if (!getter.CanBeNull())
+                        {
+                            var transform = Expression.Convert(getter, typeof(Nullable<>).MakeGenericType(getter.Type));
+                            return Expression.Condition(condition, transform, transform.Type.CreateDefault());
+                        }
+                        else
+                            return Expression.Condition(condition, getter, getter.Type.CreateDefault());
+                    }
+                    
                 }
 
                 if (expr.CanBeNull())

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -421,27 +421,13 @@ namespace Mapster.Utils
                     break;
                 if (expr.NodeType == ExpressionType.Parameter && condition != null)
                 {
-                    if(mapType != MapType.MapToTarget)
+                    if (!getter.CanBeNull())
                     {
-                        if (property.DestinationMember.Type.CanBeNull() && !getter.CanBeNull())
-                        {
-                            var transform = Expression.Convert(getter, typeof(Nullable<>).MakeGenericType(getter.Type));
-                            return Expression.Condition(condition, transform, transform.Type.CreateDefault());
-                        }
-                        else
-                            return Expression.Condition(condition, getter, getter.Type.CreateDefault());
+                        var transform = Expression.Convert(getter, typeof(Nullable<>).MakeGenericType(getter.Type));
+                        return Expression.Condition(condition, transform, transform.Type.CreateDefault());
                     }
                     else
-                    {
-                        if (!getter.CanBeNull())
-                        {
-                            var transform = Expression.Convert(getter, typeof(Nullable<>).MakeGenericType(getter.Type));
-                            return Expression.Condition(condition, transform, transform.Type.CreateDefault());
-                        }
-                        else
-                            return Expression.Condition(condition, getter, getter.Type.CreateDefault());
-                    }
-                    
+                        return Expression.Condition(condition, getter, getter.Type.CreateDefault());
                 }
 
                 if (expr.CanBeNull())
@@ -546,9 +532,22 @@ namespace Mapster.Utils
             return Expression.Constant(converter);
         }
 
-        public static bool IsNullableType(this Type type)
+        public static bool IsNotPrimitiveNullableType(this Type type)
         {
-            return Nullable.GetUnderlyingType(type) != null;
+            return Nullable.GetUnderlyingType(type) != null && !type.IsMapsterPrimitive();
+        }
+
+        public static Expression GetNotPrimitiveNullableValue(this Expression exp)
+        {
+            if (exp.Type.IsNotPrimitiveNullableType())
+            {
+                var getValueOrDefaultMethod = exp.Type.GetMethod("GetValueOrDefault", Type.EmptyTypes);
+                var getValue = Expression.Call(exp, getValueOrDefaultMethod);
+
+                return getValue;
+            }
+
+            return exp;
         }
 
     }

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -407,7 +407,7 @@ namespace Mapster.Utils
 
             return param;
         }
-        public static Expression ApplyPropertyNullPropagation(this Expression getter, MemberMapping property, MapType mapType)
+        public static Expression ApplyPropertyNullPropagation(this Expression getter)
         {
             var current = getter;
             var result = getter;

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -546,5 +546,10 @@ namespace Mapster.Utils
             return Expression.Constant(converter);
         }
 
+        public static bool IsNullableType(this Type type)
+        {
+            return Nullable.GetUnderlyingType(type) != null;
+        }
+
     }
 }


### PR DESCRIPTION
#858 Bug overview:
Nullable custom ValueType not mapping to custom ValueType
or NotNullable custom ValueType on a potentially nullable path: `property<Class>.property<ValueType>`

Causes of occurrence:
1) Not adapter for custom Nullable ValueType 
2) ApplyNullPropagation algoritm

If custom ValueType on a potentially nullable path: `property<Class>.property<ValueType>` ApplyNullPropagation tranform it to `(Nullable<ValueType>) property<Class>.property<ValueType> `  
What is actually required only in the case of MapToTarget is to support IgnoreNullValues feature

Since an initially NotNullable  source becomes nullable and can be skipped when the value is null

before ApplyNullPropagation 
`Expression (property<Class>.property<ValueType>) return ValueType data - not null `

after ApplyNullPropagation  
`Expression ((Nullable<ValueType>) property<Class>.property<ValueType>) return Nullable<ValueType> data - can be null `



