### PR TITLE
Use inheritdoc for documented mapper interface members

### DIFF
--- a/src/ExpressionTranslator/ExpressionTranslator.cs
+++ b/src/ExpressionTranslator/ExpressionTranslator.cs
@@ -36,6 +36,8 @@ namespace ExpressionDebugger
         private List<PropertyDefinitions>? _properties;
         public List<PropertyDefinitions> Properties => _properties ??= new List<PropertyDefinitions>();
 
+        private HashSet<string>? _inheritDocMembers;
+
         public bool HasDynamic { get; private set; }
         public TypeDefinitions? Definitions { get; }
 
@@ -44,6 +46,18 @@ namespace ExpressionDebugger
             Definitions = definitions;
             _writer = new StringWriter();
             ResetIndentLevel();
+        }
+
+        public void AddInheritDocMember(string memberName)
+        {
+            _inheritDocMembers ??= new HashSet<string>();
+            _inheritDocMembers.Add(memberName);
+        }
+
+        private void WriteInheritDocIfNeeded(string memberName)
+        {
+            if (_inheritDocMembers?.Contains(memberName) == true)
+                WriteNextLine("/// <inheritdoc />");
         }
 
         private void ResetIndentLevel()
@@ -1204,6 +1218,7 @@ namespace ExpressionDebugger
                     if (!isInternal)
                         isInternal = node.ReturnType.GetTypeInfo().IsNotPublic ||
                                      node.Parameters.Any(it => it.Type.GetTypeInfo().IsNotPublic);
+                    WriteInheritDocIfNeeded(name);
                     WriteModifierNextLine(isInternal ? "internal" : "public");
                     var funcType = MakeDelegateType(node.ReturnType, node.Parameters.Select(it => it.Type).ToArray());
                     var exprType = typeof(Expression<>).MakeGenericType(funcType);
@@ -1238,6 +1253,7 @@ namespace ExpressionDebugger
                     if (!isInternal)
                         isInternal = node.ReturnType.GetTypeInfo().IsNotPublic ||
                                      node.Parameters.Any(it => it.Type.GetTypeInfo().IsNotPublic);
+                    WriteInheritDocIfNeeded(name);
                     WriteModifierNextLine(isInternal ? "internal" : "public");
                     Methods[name] = node.Type;
                 }

--- a/src/Mapster.Tool.Tests/Mappers/IUserMapper.cs
+++ b/src/Mapster.Tool.Tests/Mappers/IUserMapper.cs
@@ -5,7 +5,12 @@ namespace Mapster.Tool.Tests.Mappers;
 [Mapper]
 public interface IUserMapper
 {
+    /// <summary>Gets the user projection expression.</summary>
     Expression<Func<_User, _UserDto>> UserProjection { get; }
+
+    /// <summary>Maps a user to a DTO.</summary>
     _UserDto MapTo(_User user);
+
+    /// <summary>Maps a user onto an existing DTO.</summary>
     _UserDto MapTo(_User user, _UserDto userDto);
 }

--- a/src/Mapster.Tool.Tests/Mappers/UserMapper.cs
+++ b/src/Mapster.Tool.Tests/Mappers/UserMapper.cs
@@ -7,11 +7,13 @@ namespace Mapster.Tool.Tests.Mappers
 {
     public partial class UserMapper : IUserMapper
     {
+        /// <inheritdoc />
         public Expression<Func<_User, _UserDto>> UserProjection => p1 => new _UserDto()
         {
             Id = p1.Id,
             Name = p1.Name
         };
+        /// <inheritdoc />
         public _UserDto MapTo(_User p2)
         {
             return p2 == null ? null : new _UserDto()
@@ -20,6 +22,7 @@ namespace Mapster.Tool.Tests.Mappers
                 Name = p2.Name
             };
         }
+        /// <inheritdoc />
         public _UserDto MapTo(_User p3, _UserDto p4)
         {
             if (p3 == null)

--- a/src/Mapster.Tool.Tests/Mapster.Tool.Tests.csproj
+++ b/src/Mapster.Tool.Tests/Mapster.Tool.Tests.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
 		<IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/src/Mapster.Tool.Tests/WhenGeneratingMapperWithDocumentation.cs
+++ b/src/Mapster.Tool.Tests/WhenGeneratingMapperWithDocumentation.cs
@@ -1,0 +1,18 @@
+using FluentAssertions;
+
+namespace Mapster.Tool.Tests;
+
+public class WhenGeneratingMapperWithDocumentation
+{
+    [Fact]
+    public void GeneratedMapperShouldIncludeInheritDocForDocumentedMembers()
+    {
+        var generatedMapperPath = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "Mappers", "UserMapper.cs")
+        );
+
+        File.Exists(generatedMapperPath).Should().BeTrue();
+        var content = File.ReadAllText(generatedMapperPath);
+        content.Should().Contain("/// <inheritdoc />");
+    }
+}

--- a/src/Mapster.Tool/Program.cs
+++ b/src/Mapster.Tool/Program.cs
@@ -138,6 +138,8 @@ namespace Mapster.Tool
                         var funcArgs = propArgs.GetGenericArguments();
                         var tuple = new TypeTuple(funcArgs[0], funcArgs[1]);
                         var expr = config.CreateMapExpression(tuple, MapType.Projection);
+                        if (XmlDocumentationReader.HasDocumentation(assembly, prop))
+                            translator.AddInheritDocMember(prop.Name);
                         translator.VisitLambda(
                             expr,
                             ExpressionTranslator.LambdaType.PublicLambda,
@@ -162,6 +164,8 @@ namespace Mapster.Tool
                             tuple,
                             methodArgs.Length == 1 ? MapType.Map : MapType.MapToTarget
                         );
+                        if (XmlDocumentationReader.HasDocumentation(assembly, method))
+                            translator.AddInheritDocMember(method.Name);
                         translator.VisitLambda(
                             expr,
                             ExpressionTranslator.LambdaType.PublicMethod,

--- a/src/Mapster.Tool/XmlDocumentationReader.cs
+++ b/src/Mapster.Tool/XmlDocumentationReader.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Xml.Linq;
+
+namespace Mapster.Tool
+{
+    internal static class XmlDocumentationReader
+    {
+        public static bool HasDocumentation(Assembly assembly, MemberInfo member)
+        {
+            var assemblyPath = assembly.Location;
+            if (string.IsNullOrEmpty(assemblyPath))
+                return false;
+
+            var xmlPath = Path.ChangeExtension(assemblyPath, ".xml");
+            if (!File.Exists(xmlPath))
+                return false;
+
+            var memberId = DocumentationCommentId.CreateMemberId(member);
+            var element = XDocument.Load(xmlPath)
+                .Root?
+                .Element("members")?
+                .Elements("member")
+                .FirstOrDefault(it => (string?)it.Attribute("name") == memberId);
+
+            return element != null &&
+                   element.Elements().Any(it => !string.IsNullOrWhiteSpace(it.Value));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- When `dotnet mapster mapper` generates implementation classes from `[Mapper]` interfaces, members that have XML documentation now receive `/// <inheritdoc />` in the generated code.
- Adds `XmlDocumentationReader` to detect documented interface members via the assembly XML doc file.
- Extends `ExpressionTranslator` with optional inheritdoc output for public generated members.
- Adds test coverage with documented `IUserMapper` and a regression test.

Fixes #565

## Test plan

- [ ] Build `Mapster.Tool.Tests` on net8.0+
- [ ] Run `dotnet test src/Mapster.Tool.Tests/Mapster.Tool.Tests.csproj`
- [ ] Run `dotnet mapster mapper` against an assembly with documented `[Mapper]` interfaces and verify generated `.g.cs` files include `/// <inheritdoc />`