### PR TITLE
fix: skip destination transforms for explicit member maps (#952)

### DIFF
--- a/src/Mapster.Tests/WhenPerformingDestinationTransforms.cs
+++ b/src/Mapster.Tests/WhenPerformingDestinationTransforms.cs
@@ -95,6 +95,19 @@ namespace Mapster.Tests
             destination.Set.Count.ShouldBe(0);
         }
 
+        [TestMethod]
+        public void Explicit_Null_Mapping_Is_Not_Overridden_By_EmptyCollectionIfNull()
+        {
+            var config = new TypeAdapterConfig();
+            config.Default.AddDestinationTransform(DestinationTransform.EmptyCollectionIfNull);
+            config.NewConfig<ExplicitNullSource, ExplicitNullDestination>()
+                .Map(d => d.Strings, _ => (string[]?)null);
+
+            var destination = new ExplicitNullSource([]).Adapt<ExplicitNullDestination>(config);
+
+            destination.Strings.ShouldBeNull();
+        }
+
         #region TestClasses
 
         public class SimplePoco
@@ -143,6 +156,13 @@ namespace Mapster.Tests
             public double[,] MultiDimentionalArray { get; set; }
             public IReadOnlyDictionary<string, ChildDto> ChildDict { get; set; }
             public ISet<string> Set { get; set; }
+        }
+
+        public record ExplicitNullSource(string?[] Strings);
+
+        public class ExplicitNullDestination
+        {
+            public string[]? Strings { get; set; }
         }
 
         #endregion

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -497,7 +497,7 @@ namespace Mapster.Adapters
                 : CreateAdaptExpressionCore(_source, destinationType, arg, mapping, destination);
 
             //transform(adapt(_source));
-            if (notUsingDestinationValue)
+            if (notUsingDestinationValue && !HasExplicitMemberMap(mapping, arg))
             {
                 var transform = arg.Settings.DestinationTransforms.Find(it => it.Condition(exp.Type));
                 if (transform != null)
@@ -520,6 +520,17 @@ namespace Mapster.Adapters
             }
 
             return exp.To(destinationType);
+        }
+
+        static bool HasExplicitMemberMap(MemberMapping? mapping, CompileArgument arg)
+        {
+            if (mapping?.DestinationMember == null)
+                return false;
+
+            var memberName = mapping.DestinationMember.Name;
+            return arg.Settings.Resolvers.Any(resolver =>
+                !resolver.IsChildPath &&
+                resolver.DestinationMemberName.Equals(memberName, StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Skip global `DestinationTransform` rules when a member has an explicit `.Map(...)` resolver
- Add regression test for `EmptyCollectionIfNull` with an explicit null mapping

Fixes #952

## Test plan
- [ ] CI passes
- [ ] Existing destination transform tests still pass
- [ ] Explicit `.Map(..., _ => null)` keeps null instead of empty collection