### PR TITLE
fix: let explicit Map override inherited Ignore rules (#953)

### DIFF
--- a/src/Mapster.Tests/WhenMappingWithExplicitInheritance.cs
+++ b/src/Mapster.Tests/WhenMappingWithExplicitInheritance.cs
@@ -97,6 +97,30 @@ namespace Mapster.Tests
         }
 
         [TestMethod]
+        public void Child_Explicit_Map_Overrides_Base_Ignore()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .Ignore(dest => dest.Name)
+                .Compile();
+
+            TypeAdapterConfig<DerivedPoco, DerivedDto>.NewConfig()
+                .Inherits<SimplePoco, SimpleDto>()
+                .Map(dest => dest.Name, src => src.Name)
+                .Compile();
+
+            var source = new DerivedPoco
+            {
+                Id = new Guid(),
+                Name = "SourceName"
+            };
+
+            var dto = TypeAdapter.Adapt<DerivedDto>(source);
+
+            dto.Id.ShouldBe(source.Id);
+            dto.Name.ShouldBe(source.Name);
+        }
+
+        [TestMethod]
         public void Derived_Config_Shares_Base_Config_Properties()
         {
             TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -31,6 +31,12 @@ namespace Mapster
                 throw new InvalidOperationException("TypeAdapter.Adapt was already called, please clone or create new TypeAdapterConfig.");
         }
 
+        internal static void AddMemberResolver<TSetter>(this TSetter setter, InvokerModel resolver) where TSetter : TypeAdapterSetter
+        {
+            setter.Settings.Resolvers.Add(resolver);
+            setter.Settings.Ignore.TryRemove(resolver.DestinationMemberName, out _);
+        }
+
         public static TSetter AddDestinationTransform<TSetter, TDestinationMember>(this TSetter setter, Expression<Func<TDestinationMember, TDestinationMember>> transform) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
@@ -147,7 +153,7 @@ namespace Mapster
             setter.CheckCompiled();
 
             var invoker = Expression.Lambda(source.Body, Expression.Parameter(typeof(object)));
-            setter.Settings.Resolvers.Add(new InvokerModel
+            setter.AddMemberResolver(new InvokerModel
             {
                 DestinationMemberName = memberName,
                 Invoker = invoker,
@@ -163,7 +169,7 @@ namespace Mapster
         {
             setter.CheckCompiled();
 
-            setter.Settings.Resolvers.Add(new InvokerModel
+            setter.AddMemberResolver(new InvokerModel
             {
                 DestinationMemberName = memberName,
                 SourceMemberName = source.GetMemberPath(noError: true),
@@ -179,7 +185,7 @@ namespace Mapster
         {
             setter.CheckCompiled();
 
-            setter.Settings.Resolvers.Add(new InvokerModel
+            setter.AddMemberResolver(new InvokerModel
             {
                 DestinationMemberName = destinationMemberName,
                 SourceMemberName = sourceMemberName,
@@ -399,7 +405,7 @@ namespace Mapster
                 return this;
             }
 
-            Settings.Resolvers.Add(new InvokerModel
+            this.AddMemberResolver(new InvokerModel
             {
                 DestinationMemberName = member.GetMemberPath()!,
                 Invoker = invoker,
@@ -420,7 +426,7 @@ namespace Mapster
                 return this;
             }
 
-            Settings.Resolvers.Add(new InvokerModel
+            this.AddMemberResolver(new InvokerModel
             {
                 DestinationMemberName = destinationMember.GetMemberPath()!,
                 SourceMemberName = sourceMemberName,
@@ -612,7 +618,7 @@ namespace Mapster
                 return this;
             }
 
-            Settings.Resolvers.Add(new InvokerModel
+            this.AddMemberResolver(new InvokerModel
             {
                 DestinationMemberName = member.GetMemberPath()!,
                 SourceMemberName = sourceName,
@@ -628,7 +634,7 @@ namespace Mapster
         {
             this.CheckCompiled();
 
-            Settings.Resolvers.Add(new InvokerModel
+            this.AddMemberResolver(new InvokerModel
             {
                 DestinationMemberName = memberName,
                 SourceMemberName = source.GetMemberPath(noError: true),


### PR DESCRIPTION
## Summary
- Remove inherited ignore entries when a child config registers an explicit `.Map(...)` resolver
- Add regression test for `.Inherits()` + base `.Ignore()` + child `.Map()`

Fixes #953

## Test plan
- [ ] CI passes
- [ ] Existing explicit inheritance tests still pass
- [ ] Child `.Map()` restores mapping for members ignored in base config