### PR TITLE
fix: handle optional value-type constructor defaults (#954)

### DIFF
--- a/src/Mapster.Tests/WhenMappingRecordWithOptionalDateTimeConstructor.cs
+++ b/src/Mapster.Tests/WhenMappingRecordWithOptionalDateTimeConstructor.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenMappingRecordWithOptionalDateTimeConstructor
+    {
+        [TestMethod]
+        public void Record_With_DateTime_Maps_To_Class_With_Optional_DateTime_Constructor()
+        {
+            var source = new DateTimeFoo(DateTime.Today);
+            var destination = source.Adapt<DateTimeFooDto>();
+
+            destination.Timestamp.ShouldBe(source.Timestamp);
+        }
+
+        public class DateTimeFooDto
+        {
+            public DateTime Timestamp { get; set; }
+
+            public DateTimeFooDto(DateTime timestamp = default)
+            {
+                Timestamp = timestamp;
+            }
+        }
+
+        public record DateTimeFoo(DateTime Timestamp);
+    }
+}

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -211,7 +211,7 @@ namespace Mapster.Adapters
             {
                 var parameterInfo = (ParameterInfo)member.DestinationMember.Info!;
                 var defaultConst = parameterInfo.IsOptional
-                    ? Expression.Constant(parameterInfo.DefaultValue, member.DestinationMember.Type)
+                    ? CreateOptionalParameterDefault(parameterInfo, member.DestinationMember.Type)
                     : parameterInfo.ParameterType.CreateDefault();
 
                 Expression getter;
@@ -257,6 +257,15 @@ namespace Mapster.Adapters
             }
 
             return Expression.New(classConverter.ConstructorInfo!, arguments);
+        }
+
+        static Expression CreateOptionalParameterDefault(ParameterInfo parameterInfo, Type destinationType)
+        {
+            var defaultValue = parameterInfo.DefaultValue;
+            if (defaultValue == null || defaultValue is DBNull)
+                return destinationType.CreateDefault();
+
+            return Expression.Constant(defaultValue, destinationType);
         }
 
         protected virtual ClassModel GetConstructorModel(ConstructorInfo ctor, bool breakOnUnmatched)


### PR DESCRIPTION
## Summary
- Fall back to `CreateDefault()` when optional constructor parameters report a null `DefaultValue`
- Fixes compile failures mapping records with `DateTime` members to classes with optional `DateTime` constructor parameters
- Add regression test from issue repro

Fixes #954

## Test plan
- [ ] CI passes
- [ ] `WhenMappingRecordWithOptionalDateTimeConstructor` succeeds