### PR TITLE
fix: skip abstract base mapping when nested source is null (#928)

### DIFF
--- a/src/Mapster.Tests/WhenMappingNullableAbstractWithInclude.cs
+++ b/src/Mapster.Tests/WhenMappingNullableAbstractWithInclude.cs
@@ -1,0 +1,78 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenMappingNullableAbstractWithInclude
+    {
+        [TestMethod]
+        public void Null_Abstract_Property_With_Include_Maps_To_Null()
+        {
+            var config = new TypeAdapterConfig();
+            config.Default.MapToConstructor(true);
+            config
+                .NewConfig<DtoBase, DomainBase>()
+                .Include<DtoDerived, DomainDerived>();
+
+            var dto = new DtoFoo { Field = null };
+
+            var domain = dto.Adapt<DomainFoo>(config);
+
+            domain.Field.ShouldBeNull();
+        }
+
+        [TestMethod]
+        public void Derived_Abstract_Property_With_Include_Maps_To_Derived_Domain()
+        {
+            var config = new TypeAdapterConfig();
+            config.Default.MapToConstructor(true);
+            config
+                .NewConfig<DtoBase, DomainBase>()
+                .Include<DtoDerived, DomainDerived>();
+
+            var dto = new DtoFoo
+            {
+                Field = new DtoDerived { Id = "id" },
+            };
+
+            var domain = dto.Adapt<DomainFoo>(config);
+
+            domain.Field.ShouldNotBeNull();
+            domain.Field.ShouldBeOfType<DomainDerived>();
+            ((DomainDerived)domain.Field).Id.ShouldBe("id");
+        }
+
+        #region test classes
+
+        public abstract class DtoBase
+        {
+        }
+
+        public class DtoDerived : DtoBase
+        {
+            public string Id { get; set; } = null!;
+        }
+
+        public class DtoFoo
+        {
+            public DtoBase? Field { get; set; }
+        }
+
+        public abstract class DomainBase
+        {
+        }
+
+        public class DomainDerived : DomainBase
+        {
+            public string Id { get; set; } = null!;
+        }
+
+        public class DomainFoo
+        {
+            public DomainBase? Field { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -496,6 +496,13 @@ namespace Mapster.Adapters
                 ? _source
                 : CreateAdaptExpressionCore(_source, destinationType, arg, mapping, destination);
 
+            if (notUsingDestinationValue
+                && _source.CanBeNull()
+                && destinationType.IsAbstractOrNotPublicCtor())
+            {
+                exp = _source.NotNullReturn(exp);
+            }
+
             //transform(adapt(_source));
             if (notUsingDestinationValue)
             {


### PR DESCRIPTION
## Summary
- When mapping a nullable abstract/base property configured with `Include<,>()`, Mapster attempted to adapt through the abstract destination type even when the source value was `null`, throwing `Cannot instantiate type` at runtime
- Short-circuit null sources in `CreateAdaptExpression` before adapting to abstract or non-public-ctor destination types

Fixes #928

## Test plan
- [ ] CI passes (`WhenMappingNullableAbstractWithInclude` covers null and derived cases with `MapToConstructor(true)`)