### PR TITLE
fix: skip destination transforms for explicit member maps (#952, ctor path)

### DIFF
--- a/src/Mapster.Tests/WhenPerformingDestinationTransforms.cs
+++ b/src/Mapster.Tests/WhenPerformingDestinationTransforms.cs
@@ -95,6 +95,19 @@ namespace Mapster.Tests
             destination.Set.Count.ShouldBe(0);
         }
 
+        [TestMethod]
+        public void Explicit_Null_Mapping_Is_Not_Overridden_By_EmptyCollectionIfNull()
+        {
+            var config = new TypeAdapterConfig();
+            config.Default.AddDestinationTransform(DestinationTransform.EmptyCollectionIfNull);
+            config.NewConfig<ExplicitNullSource, ExplicitNullDestination>()
+                .Map(d => d.Strings, _ => (string[]?)null);
+
+            var destination = new ExplicitNullSource([]).Adapt<ExplicitNullDestination>(config);
+
+            destination.Strings.ShouldBeNull();
+        }
+
         #region TestClasses
 
         public class SimplePoco
@@ -143,6 +156,13 @@ namespace Mapster.Tests
             public double[,] MultiDimentionalArray { get; set; }
             public IReadOnlyDictionary<string, ChildDto> ChildDict { get; set; }
             public ISet<string> Set { get; set; }
+        }
+
+        public record ExplicitNullSource(string?[] Strings);
+
+        public class ExplicitNullDestination
+        {
+            public string[]? Strings { get; set; }
         }
 
         #endregion

--- a/src/Mapster.Tests/WhenPerformingDestinationTransforms.cs
+++ b/src/Mapster.Tests/WhenPerformingDestinationTransforms.cs
@@ -108,6 +108,19 @@ namespace Mapster.Tests
             destination.Strings.ShouldBeNull();
         }
 
+        [TestMethod]
+        public void Explicit_Null_Record_Ctor_Mapping_Is_Not_Overridden_By_EmptyCollectionIfNull()
+        {
+            var config = new TypeAdapterConfig();
+            config.Default.AddDestinationTransform(DestinationTransform.EmptyCollectionIfNull);
+            config.NewConfig<ExplicitNullSource, ExplicitNullRecordDestination>()
+                .Map(d => d.Strings, _ => (string[]?)null);
+
+            var destination = new ExplicitNullSource([]).Adapt<ExplicitNullRecordDestination>(config);
+
+            destination.Strings.ShouldBeNull();
+        }
+
         #region TestClasses
 
         public class SimplePoco
@@ -164,6 +177,8 @@ namespace Mapster.Tests
         {
             public string[]? Strings { get; set; }
         }
+
+        public record ExplicitNullRecordDestination(string[]? Strings);
 
         #endregion
 

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -521,7 +521,7 @@ namespace Mapster.Adapters
                 exp = CreateAdaptExpressionCore(_source, destinationType, arg, mapping, destination);
 
             //transform(adapt(_source));
-            if (notUsingDestinationValue)
+            if (notUsingDestinationValue && !HasExplicitMemberMap(mapping, arg))
             {
                 var transform = arg.Settings.DestinationTransforms.Find(it => it.Condition(exp.Type));
                 if (transform != null)
@@ -544,6 +544,17 @@ namespace Mapster.Adapters
             }
 
             return exp.To(destinationType);
+        }
+
+        static bool HasExplicitMemberMap(MemberMapping? mapping, CompileArgument arg)
+        {
+            if (mapping?.DestinationMember == null)
+                return false;
+
+            var memberName = mapping.DestinationMember.Name;
+            return arg.Settings.Resolvers.Any(resolver =>
+                !resolver.IsChildPath &&
+                resolver.DestinationMemberName.Equals(memberName, StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -263,7 +263,7 @@ namespace Mapster.Adapters
                     }
                     else
                        getter = member.Getter
-                            .ApplyNullPropagationFromCtor(CreateAdaptExpressionCore(member.Getter, member.DestinationMember.Type, arg, member), arg);
+                            .ApplyNullPropagationFromCtor(CreateAdaptExpressionCore(member.Getter, member.DestinationMember.Type, arg, member), arg, member);
                     
 
                     if (member.Ignore.Condition != null)
@@ -283,7 +283,7 @@ namespace Mapster.Adapters
                            getter = TryRestoreRecordMember(member.DestinationMember, recordRestorParamModel, destination) ?? getter;
                     }
                 }
-                arguments.Add(getter);
+                arguments.Add(ExpressionEx.ApplyDestinationTransform(getter, arg, member));
             }
 
             return Expression.New(classConverter.ConstructorInfo!, arguments);

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -445,7 +445,7 @@ namespace Mapster.Utils
             return getter;
         }
 
-        public static Expression ApplyNullPropagationFromCtor(this Expression getter, Expression adapt, CompileArgument arg)
+        public static Expression ApplyNullPropagationFromCtor(this Expression getter, Expression adapt, CompileArgument arg, MemberMapping? member = null)
         {
             if (getter == null)
                 return adapt;
@@ -481,14 +481,40 @@ namespace Mapster.Utils
             }
 
             if (condition == null)
-                return adapt;
+                return ApplyDestinationTransform(adapt, arg, member);
 
             // add supporting DestinationTransforms
+            if (HasExplicitMemberMap(member, arg))
+                return Expression.Condition(condition, adapt, Expression.Default(adapt.Type));
+
             var transform = arg.Settings.DestinationTransforms.Find(it => it.Condition(adapt.Type));
             if (transform != null)
                 return transform.TransformFunc(adapt.Type).Apply(arg.MapType, Expression.Condition(condition, adapt, Expression.Default(adapt.Type)));
 
             return Expression.Condition(condition, adapt, Expression.Default(adapt.Type));
+        }
+
+        public static Expression ApplyDestinationTransform(Expression exp, CompileArgument arg, MemberMapping? mapping = null)
+        {
+            if (HasExplicitMemberMap(mapping, arg))
+                return exp;
+
+            var transform = arg.Settings.DestinationTransforms.Find(it => it.Condition(exp.Type));
+            if (transform == null)
+                return exp;
+
+            return transform.TransformFunc(exp.Type).Apply(arg.MapType, exp);
+        }
+
+        static bool HasExplicitMemberMap(MemberMapping? mapping, CompileArgument arg)
+        {
+            if (mapping?.DestinationMember == null)
+                return false;
+
+            var memberName = mapping.DestinationMember.Name;
+            return arg.Settings.Resolvers.Any(resolver =>
+                !resolver.IsChildPath &&
+                resolver.DestinationMemberName.Equals(memberName, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public static string? GetMemberPath(this LambdaExpression lambda, bool firstLevelOnly = false, bool noError = false)


### PR DESCRIPTION
## Summary
- Explicit `.Map(...)` configuration now takes precedence over global `DestinationTransform` rules such as `EmptyCollectionIfNull`
- Prevents explicit null member mappings from being overridden by collection transforms

Fixes #952

## Test plan
- [ ] CI passes (`WhenPerformingDestinationTransforms.Explicit_Null_Mapping_Is_Not_Overridden_By_EmptyCollectionIfNull`)