### PR TITLE
fix: use type default for optional DateTime constructor params (#954)

### DIFF
--- a/src/Mapster.Tests/WhenMappingRecordWithOptionalDateTimeConstructor.cs
+++ b/src/Mapster.Tests/WhenMappingRecordWithOptionalDateTimeConstructor.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenMappingRecordWithOptionalDateTimeConstructor
+    {
+        [TestMethod]
+        public void Record_With_DateTime_Maps_To_Class_With_Optional_DateTime_Constructor()
+        {
+            var source = new DateTimeFoo(DateTime.Today);
+            var destination = source.Adapt<DateTimeFooDto>();
+
+            destination.Timestamp.ShouldBe(source.Timestamp);
+        }
+
+        public class DateTimeFooDto
+        {
+            public DateTime Timestamp { get; set; }
+
+            public DateTimeFooDto(DateTime timestamp = default)
+            {
+                Timestamp = timestamp;
+            }
+        }
+
+        public record DateTimeFoo(DateTime Timestamp);
+    }
+}

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -225,23 +225,9 @@ namespace Mapster.Adapters
                 Expression defaultConst;
                 Expression getter;
 
-#if NETSTANDARD2_0
-                try
-                {
-                    defaultConst = parameterInfo.IsOptional && parameterInfo.DefaultValue != null
-                    ? Expression.Constant(parameterInfo.DefaultValue, member.DestinationMember.Type)
+                defaultConst = parameterInfo.IsOptional
+                    ? CreateOptionalParameterDefault(parameterInfo, member.DestinationMember.Type)
                     : parameterInfo.ParameterType.CreateDefault();
-                }
-                catch (FormatException)
-                {
-                    defaultConst = parameterInfo.ParameterType.CreateDefault();
-                }
-
-#else
-                defaultConst = parameterInfo.IsOptional && parameterInfo.DefaultValue != null
-                    ? Expression.Constant(parameterInfo.DefaultValue, member.DestinationMember.Type)
-                    : parameterInfo.ParameterType.CreateDefault();
-#endif
                 
                 if (member.Getter == null)
                 {
@@ -287,6 +273,15 @@ namespace Mapster.Adapters
             }
 
             return Expression.New(classConverter.ConstructorInfo!, arguments);
+        }
+
+        static Expression CreateOptionalParameterDefault(ParameterInfo parameterInfo, Type destinationType)
+        {
+            var defaultValue = parameterInfo.DefaultValue;
+            if (defaultValue == null || defaultValue is DBNull)
+                return destinationType.CreateDefault();
+
+            return Expression.Constant(defaultValue, destinationType);
         }
 
         protected virtual ClassModel GetConstructorModel(ConstructorInfo ctor, bool breakOnUnmatched)


### PR DESCRIPTION
## Summary
- Extract `CreateOptionalParameterDefault` for optional constructor parameters.
- When `DefaultValue` is null or `DBNull`, emit `destinationType.CreateDefault()` instead of `Expression.Constant(null, valueType)`.
- Adds regression test mapping a record with `DateTime` to a class with an optional `DateTime` constructor parameter.

Fixes #954

## Test plan
- [x] Added `WhenMappingRecordWithOptionalDateTimeConstructor` regression test
- [ ] CI green on `development`