### PR TITLE
fix: apply custom Map results when mapping to existing target (#900)

### DIFF
--- a/src/Mapster.Tests/WhenMappingGetterOnlyMapToTargetRegression.cs
+++ b/src/Mapster.Tests/WhenMappingGetterOnlyMapToTargetRegression.cs
@@ -1,0 +1,75 @@
+using MapsterMapper;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests;
+
+/// <summary>
+/// https://github.com/MapsterMapper/Mapster/issues/900
+/// </summary>
+[TestClass]
+public class WhenMappingGetterOnlyMapToTargetRegression
+{
+    [TestMethod]
+    public void MapToTarget_WithCustomMap_ShouldReplaceExistingDestinationMemberValue()
+    {
+        var config = new TypeAdapterConfig();
+        config.NewConfig<Dto900, Entity900>()
+            .Map(x => x.Data, x => x.Data == null ? null : new Data900(x.Data.Value));
+
+        var mapper = new Mapper(config);
+
+        var dto = new Dto900 { Data = new Data900("new") };
+        var entity = mapper.Map(dto, new Entity900 { Data = new Data900("old") });
+
+        entity.Data.ShouldNotBeNull();
+        entity.Data!.Value.ShouldBe("new");
+    }
+
+    [TestMethod]
+    public void MapToTarget_WithCustomMap_ShouldStillWorkWhenDestinationMemberIsNull()
+    {
+        var config = new TypeAdapterConfig();
+        config.NewConfig<Dto900, Entity900>()
+            .Map(x => x.Data, x => x.Data == null ? null : new Data900(x.Data.Value));
+
+        var mapper = new Mapper(config);
+
+        var dto = new Dto900 { Data = new Data900("new") };
+        var entity = mapper.Map(dto, new Entity900());
+
+        entity.Data.ShouldNotBeNull();
+        entity.Data!.Value.ShouldBe("new");
+    }
+
+    [TestMethod]
+    public void Map_WithCustomMap_ShouldStillWorkForNewDestination()
+    {
+        var config = new TypeAdapterConfig();
+        config.NewConfig<Dto900, Entity900>()
+            .Map(x => x.Data, x => x.Data == null ? null : new Data900(x.Data.Value));
+
+        var mapper = new Mapper(config);
+
+        var dto = new Dto900 { Data = new Data900("new") };
+        var entity = mapper.Map<Entity900>(dto);
+
+        entity.Data.ShouldNotBeNull();
+        entity.Data!.Value.ShouldBe("new");
+    }
+
+    private class Dto900
+    {
+        public Data900? Data { get; set; }
+    }
+
+    private class Entity900
+    {
+        public Data900? Data { get; set; }
+    }
+
+    private class Data900(string value)
+    {
+        public string Value => value;
+    }
+}

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -200,6 +200,13 @@ namespace Mapster.Adapters
             return false;
         }
 
+        protected static bool HasCustomMemberMap(CompileArgument arg, IMemberModel destinationMember)
+        {
+            return arg.Settings.Resolvers.Any(resolver =>
+                !resolver.IsChildPath &&
+                string.Equals(resolver.DestinationMemberName, destinationMember.Name, StringComparison.InvariantCultureIgnoreCase));
+        }
+
         protected static bool ProcessIgnores(
             CompileArgument arg,
             IMemberModel destinationMember,

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -110,7 +110,8 @@ namespace Mapster.Adapters
             Dictionary<LambdaExpression, Tuple<List<Expression>, Expression>>? conditions = null;
             foreach (var member in members)
             {
-                var destMember = arg.MapType == MapType.MapToTarget || member.UseDestinationValue
+                var hasCustomMap = HasCustomMemberMap(arg, member.DestinationMember);
+                var destMember = (arg.MapType == MapType.MapToTarget || member.UseDestinationValue) && !hasCustomMap
                     ? member.DestinationMember.GetExpression(destination)
                     : null;
 


### PR DESCRIPTION
## Summary
- Fixes `MapToTarget` (`mapper.Map(dto, existingEntity)`) ignoring custom `.Map()` resolvers when the destination member already has a value.
- When a destination member has an explicit custom `.Map()` configuration, skip passing the existing destination member into nested adaptation so the resolver result is assigned directly.
- Adds regression tests reproducing issue #900 for MapToTarget with pre-existing destination values, null destination members, and new-object mapping.

## Root cause
For `MapToTarget`, `ClassAdapter` always passed the existing destination member expression into `CreateAdaptExpression`. That triggered nested `MapToTarget` adaptation for the member type. For immutable/getter-only types (like primary-constructor classes), nested mapping preserves the existing destination instance instead of replacing it with the custom `.Map()` result.

## Test plan
- [ ] CI passes on `Mapster.Tests`
- [ ] `WhenMappingGetterOnlyMapToTargetRegression.MapToTarget_WithCustomMap_ShouldReplaceExistingDestinationMemberValue`
- [ ] Existing MapToTarget regression tests remain green

Fixes #900