### PR TITLE
fix: ProjectToType nullable navigation to record DTO ctor (#898)

### DIFF
--- a/src/Mapster.Tests/WhenAddCtorNullablePropagation.cs
+++ b/src/Mapster.Tests/WhenAddCtorNullablePropagation.cs
@@ -1,5 +1,5 @@
-﻿using Mapster.Tests.Classes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -15,14 +15,25 @@ namespace Mapster.Tests
         [TestMethod]
         public void NullablePropagationFromCtorWorking()
         {
-            var source = new List<OrderEntity898>();
+            var source = new List<OrderEntity898>
+            {
+                new() { Id = 1, Cod = new OrderCodEntity898 { Value = 42L } },
+                new() { Id = 2, Cod = null },
+            };
 
-            source.Add(new OrderEntity898() { Id = 1, Cod = new OrderCodEntity898 { Value = 42L } });
-            source.Add(new OrderEntity898() { Id = 2, Cod = null });
-
-            var str = new OrderEntity898() { Id = 1, Cod = new OrderCodEntity898 { Value = 42L } }.BuildAdapter().CreateProjectionExpression<OrderDto898>();
+            Should.NotThrow(() =>
+            {
+                source.AsQueryable().BuildAdapter().CreateProjectionExpression<OrderDto898>();
+            });
 
             var result = source.AsQueryable().ProjectToType<OrderDto898>().ToList();
+
+            result.Count.ShouldBe(2);
+            result[0].Id.ShouldBe(1);
+            result[0].Cod.ShouldNotBeNull();
+            result[0].Cod!.Value.ShouldBe(42L);
+            result[1].Id.ShouldBe(2);
+            result[1].Cod.ShouldBeNull();
         }
 
     }

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -218,9 +218,9 @@ namespace Mapster.Adapters
             var members = classConverter.Members;
 
             var arguments = new List<Expression>();
+            arg.Context.NullChecks.UnionWith(members.Where(x => x.Getter != null).Select(x => (x.Getter, arg)));
             foreach (var member in members)
             {
-                arg.Context.NullChecks.UnionWith(members.Where(x=>x.Getter != null).Select(x=>(x.Getter,arg)));
                 var parameterInfo = (ParameterInfo)member.DestinationMember.Info!;
                 Expression defaultConst;
                 Expression getter;
@@ -253,12 +253,13 @@ namespace Mapster.Adapters
                 else
                 {
 
-                    if (member.Getter.CanBeNull() && member.DestinationMember.Type.IsAbstractOrNotPublicCtor()
-                        && member.Ignore.Condition == null)
+                    if (member.Getter.CanBeNull() && member.Ignore.Condition == null
+                        && (member.DestinationMember.Type.IsAbstractOrNotPublicCtor()
+                            || member.DestinationMember.Type.UnwrapNullable().IsRecordType()))
                     {
                         var compareNull = Expression.Equal(member.Getter, Expression.Constant(null, member.Getter.Type));
                         getter = Expression.Condition(ExpressionEx.Not(compareNull),
-                            CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member),
+                            CreateAdaptExpressionCore(member.Getter, member.DestinationMember.Type, arg, member),
                            defaultConst);
                     }
                     else

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -453,8 +453,8 @@ namespace Mapster.Utils
             Expression? condition = null;
             var current = getter;
             var checks = arg.Context.NullChecks
-                .Where(x=> !object.ReferenceEquals(x.arg,arg))
-                .Select(x=>x.param?.Type);
+                .Where(x => !object.ReferenceEquals(x.arg, arg))
+                .Select(x => x.param);
 
             while (current != null) 
             {
@@ -462,9 +462,9 @@ namespace Mapster.Utils
 
                 if (current.CanBeNull() && current is not ParameterExpression)
                     compareNull = Expression.NotEqual(current, Expression.Constant(null, current.Type));
-                else if (current.CanBeNull() && current is ParameterExpression
-                    && !checks.Contains(current.Type))
-                    compareNull = Expression.NotEqual(current, Expression.Constant(null, current.Type));
+                else if (current.CanBeNull() && current is ParameterExpression param
+                    && !checks.Contains(param))
+                    compareNull = Expression.NotEqual(param, Expression.Constant(null, param.Type));
 
                 if (compareNull != null)
                 {


### PR DESCRIPTION
## Summary

- Fixes `ProjectToType` throwing `InvalidOperationException: Nullable object must have a value` when a nullable navigation (e.g. `Cod == null`) maps to a record DTO constructor parameter whose nested record has non-nullable value-type parameters.
- Adds an explicit null guard for nullable getters mapping to record constructor parameters (same pattern as abstract/non-public ctor types).
- Tracks `NullChecks` by expression identity instead of nullable type so nested projection parameters are not incorrectly skipped.
- Strengthens the #898 regression test with compile + execution assertions.

## Root cause

Constructor mapping for record DTOs could still evaluate nested record constructor arguments (e.g. `Cod.Value`) when the nullable navigation was null. PR #903 improved ctor null propagation, but nullable navigation → nullable record ctor parameters still needed an explicit short-circuit before nested record mapping.

## Test plan

- [x] Added/updated regression test `WhenAddCtorNullablePropagation.NullablePropagationFromCtorWorking`
- [ ] CI green on `Mapster.Tests`

Fixes MapsterMapper/Mapster#898