### PR TITLE
test: cover MapToTarget for types with read-only base properties (#918)

### DIFF
--- a/src/Mapster.Tests/WhenMappingMapToTargetMixedReadOnlyBaseRegression.cs
+++ b/src/Mapster.Tests/WhenMappingMapToTargetMixedReadOnlyBaseRegression.cs
@@ -1,0 +1,38 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    /// <summary>
+    /// https://github.com/MapsterMapper/Mapster/issues/918
+    /// </summary>
+    [TestClass]
+    public class WhenMappingMapToTargetMixedReadOnlyBaseRegression
+    {
+        [TestMethod]
+        public void MapToTarget_SameType_WithMixedReadOnlyBaseProperties_UpdatesDestination()
+        {
+            var source = new Station918 { RowNo = 100, Location = "Source" };
+            var destination = new Station918 { RowNo = 0, Location = "Destination" };
+
+            source.Adapt(destination);
+
+            destination.RowNo.ShouldBe(100);
+            destination.Location.ShouldBe("Source");
+        }
+
+        public abstract class ValidationBase918
+        {
+            public bool HasErrors { get; }
+
+            public string? ErrorMessage { get; }
+        }
+
+        public class Station918 : ValidationBase918
+        {
+            public int RowNo { get; set; }
+
+            public string Location { get; set; } = string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds regression test for same-type `Adapt(target)` when the type inherits read-only base members (ObservableValidator-like pattern) alongside writable properties.

Relates to #918 (fixed on `development` via `IsNotSelfCreation` `Any` → `All` change).

## Test plan
- [x] `MapToTarget_SameType_WithMixedReadOnlyBaseProperties_UpdatesDestination`
- [ ] CI green on `development`