### PR TITLE
fix: apply EmptyCollectionIfNull to record constructor args (#943)

### DIFF
--- a/src/Mapster.Tests/WhenExplicitNullDestinationTransformRegression.cs
+++ b/src/Mapster.Tests/WhenExplicitNullDestinationTransformRegression.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    /// <summary>
+    /// https://github.com/MapsterMapper/Mapster/issues/952
+    /// </summary>
+    [TestClass]
+    public class WhenExplicitNullDestinationTransformRegression
+    {
+        [TestMethod]
+        public void ExplicitNullMapping_ShouldNotBeOverridden_ByDefaultEmptyCollectionTransform()
+        {
+            var config = new TypeAdapterConfig();
+
+            config.Default
+                .AddDestinationTransform(DestinationTransform.EmptyCollectionIfNull);
+
+            config.NewConfig<Foo952, FooDto952>()
+                .Map(d => d.Strings, _ => (string[]?)null);
+
+            var foo = new Foo952([]);
+
+            var dto = foo.Adapt<FooDto952>(config);
+
+            dto.Strings.ShouldBeNull();
+        }
+
+        record Foo952(string?[] Strings);
+
+        class FooDto952
+        {
+            public string[]? Strings { get; set; }
+        }
+    }
+}

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -283,7 +283,7 @@ namespace Mapster.Adapters
                            getter = TryRestoreRecordMember(member.DestinationMember, recordRestorParamModel, destination) ?? getter;
                     }
                 }
-                arguments.Add(getter);
+                arguments.Add(ExpressionEx.ApplyDestinationTransform(getter, arg));
             }
 
             return Expression.New(classConverter.ConstructorInfo!, arguments);

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -263,7 +263,7 @@ namespace Mapster.Adapters
                     }
                     else
                        getter = member.Getter
-                            .ApplyNullPropagationFromCtor(CreateAdaptExpressionCore(member.Getter, member.DestinationMember.Type, arg, member), arg);
+                            .ApplyNullPropagationFromCtor(CreateAdaptExpressionCore(member.Getter, member.DestinationMember.Type, arg, member), arg, member);
                     
 
                     if (member.Ignore.Condition != null)
@@ -283,7 +283,7 @@ namespace Mapster.Adapters
                            getter = TryRestoreRecordMember(member.DestinationMember, recordRestorParamModel, destination) ?? getter;
                     }
                 }
-                arguments.Add(ExpressionEx.ApplyDestinationTransform(getter, arg));
+                arguments.Add(ExpressionEx.ApplyDestinationTransform(getter, arg, member));
             }
 
             return Expression.New(classConverter.ConstructorInfo!, arguments);

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -481,7 +481,7 @@ namespace Mapster.Utils
             }
 
             if (condition == null)
-                return adapt;
+                return ApplyDestinationTransform(adapt, arg);
 
             // add supporting DestinationTransforms
             var transform = arg.Settings.DestinationTransforms.Find(it => it.Condition(adapt.Type));
@@ -489,6 +489,15 @@ namespace Mapster.Utils
                 return transform.TransformFunc(adapt.Type).Apply(arg.MapType, Expression.Condition(condition, adapt, Expression.Default(adapt.Type)));
 
             return Expression.Condition(condition, adapt, Expression.Default(adapt.Type));
+        }
+
+        public static Expression ApplyDestinationTransform(Expression exp, CompileArgument arg)
+        {
+            var transform = arg.Settings.DestinationTransforms.Find(it => it.Condition(exp.Type));
+            if (transform == null)
+                return exp;
+
+            return transform.TransformFunc(exp.Type).Apply(arg.MapType, exp);
         }
 
         public static string? GetMemberPath(this LambdaExpression lambda, bool firstLevelOnly = false, bool noError = false)

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -445,7 +445,7 @@ namespace Mapster.Utils
             return getter;
         }
 
-        public static Expression ApplyNullPropagationFromCtor(this Expression getter, Expression adapt, CompileArgument arg)
+        public static Expression ApplyNullPropagationFromCtor(this Expression getter, Expression adapt, CompileArgument arg, MemberMapping? member = null)
         {
             if (getter == null)
                 return adapt;
@@ -481,9 +481,12 @@ namespace Mapster.Utils
             }
 
             if (condition == null)
-                return ApplyDestinationTransform(adapt, arg);
+                return ApplyDestinationTransform(adapt, arg, member);
 
             // add supporting DestinationTransforms
+            if (HasExplicitMemberMap(member, arg))
+                return Expression.Condition(condition, adapt, Expression.Default(adapt.Type));
+
             var transform = arg.Settings.DestinationTransforms.Find(it => it.Condition(adapt.Type));
             if (transform != null)
                 return transform.TransformFunc(adapt.Type).Apply(arg.MapType, Expression.Condition(condition, adapt, Expression.Default(adapt.Type)));
@@ -491,13 +494,27 @@ namespace Mapster.Utils
             return Expression.Condition(condition, adapt, Expression.Default(adapt.Type));
         }
 
-        public static Expression ApplyDestinationTransform(Expression exp, CompileArgument arg)
+        public static Expression ApplyDestinationTransform(Expression exp, CompileArgument arg, MemberMapping? mapping = null)
         {
+            if (HasExplicitMemberMap(mapping, arg))
+                return exp;
+
             var transform = arg.Settings.DestinationTransforms.Find(it => it.Condition(exp.Type));
             if (transform == null)
                 return exp;
 
             return transform.TransformFunc(exp.Type).Apply(arg.MapType, exp);
+        }
+
+        static bool HasExplicitMemberMap(MemberMapping? mapping, CompileArgument arg)
+        {
+            if (mapping?.DestinationMember == null)
+                return false;
+
+            var memberName = mapping.DestinationMember.Name;
+            return arg.Settings.Resolvers.Any(resolver =>
+                !resolver.IsChildPath &&
+                resolver.DestinationMemberName.Equals(memberName, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public static string? GetMemberPath(this LambdaExpression lambda, bool firstLevelOnly = false, bool noError = false)


### PR DESCRIPTION
## Summary
- Apply `EmptyCollectionIfNull` (and other destination transforms) to record/class constructor arguments when null sources would otherwise skip transforms.
- Skip destination transforms when a member has an explicit `.Map()` resolver so explicit null mappings are preserved.

Fixes #943
Relates to #952 (ctor-parameter path; property path covered by #966)

## Test plan
- [x] `NullableCtorPropagationCurrentWorkWithDestinationTransform` (#943)
- [x] `ExplicitNullMapping_ShouldNotBeOverridden_ByDefaultEmptyCollectionTransform` (#952)
- [ ] CI green on `development`