### PR TITLE
fix: honor per-type ShallowCopyForSameType overrides (#938)

### DIFF
--- a/src/Mapster.Tests/WhenPerTypeShallowCopyOverride.cs
+++ b/src/Mapster.Tests/WhenPerTypeShallowCopyOverride.cs
@@ -1,0 +1,108 @@
+using Mapster.Models;
+using MapsterMapper;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    /// <summary>
+    /// https://github.com/MapsterMapper/Mapster/issues/938
+    /// </summary>
+    [TestClass]
+    public class WhenPerTypeShallowCopyOverride
+    {
+        [TestMethod]
+        public void GlobalShallowCopy_WithPerTypeDeepCopy_ShouldRestoreViaMapToTarget()
+        {
+            var cfg = new TypeAdapterConfig();
+            cfg.RequireExplicitMapping = true;
+            cfg.Default.ShallowCopyForSameType(true);
+            cfg.Default.AvoidInlineMapping(true);
+
+            cfg.NewConfig<RandomObject2, RandomObject2>();
+            cfg.NewConfig<RandomObject1, RandomObject1>();
+
+            cfg.NewConfig<MyFailStuff, MyFailStuff>()
+                .ShallowCopyForSameType(false);
+
+            cfg.GetMergedSettings(new TypeTuple(typeof(MyFailStuff), typeof(MyFailStuff)), MapType.Map)
+                .ShallowCopyForSameType.ShouldBe(false);
+
+            cfg.Compile();
+
+            var mapper = new Mapper(cfg);
+
+            var dynamicStuff = new MyFailStuff();
+            dynamicStuff.Item1 = new RandomObject1();
+            dynamicStuff.Item1.SampleName = "SN1";
+            dynamicStuff.Item2 = new RandomObject2();
+            dynamicStuff.Item2.SampleNumber = 2;
+
+            var originalStuff = mapper.Map<MyFailStuff, MyFailStuff>(dynamicStuff);
+
+            dynamicStuff.Item1.SampleName = "SN1CHANGED";
+            dynamicStuff.Item2.SampleNumber = 3;
+
+            mapper.Map(originalStuff, dynamicStuff);
+
+            dynamicStuff.Item1.SampleName.ShouldBe("SN1");
+            dynamicStuff.Item2.SampleNumber.ShouldBe(2);
+            ReferenceEquals(dynamicStuff.Item1, originalStuff.Item1).ShouldBeFalse();
+            ReferenceEquals(dynamicStuff.Item2, originalStuff.Item2).ShouldBeFalse();
+        }
+
+        [TestMethod]
+        public void ParentDeepCopyOverride_ShouldNotDisableImplicitNestedShallowCopyForSameType()
+        {
+            var cfg = new TypeAdapterConfig();
+            cfg.Default.ShallowCopyForSameType(true);
+            cfg.NewConfig<Container, Container>()
+                .ShallowCopyForSameType(false);
+
+            cfg.Compile();
+
+            var src = new Container { Child = new NestedChild { Value = 1 } };
+            var dest = src.Adapt<Container>(cfg);
+
+            ReferenceEquals(src.Child, dest.Child).ShouldBeTrue();
+        }
+
+        public class Container
+        {
+            public NestedChild? Child { get; set; }
+        }
+
+        public class NestedChild
+        {
+            public int Value { get; set; }
+        }
+
+        public class MyFailStuff
+        {
+            public MyFailStuff()
+            {
+                CreateEmptyEntities();
+            }
+
+            public void CreateEmptyEntities()
+            {
+                Item1 ??= new RandomObject1();
+                Item2 ??= new RandomObject2();
+            }
+
+            public RandomObject1? Item1 { get; set; }
+
+            public RandomObject2? Item2 { get; set; }
+        }
+
+        public class RandomObject1
+        {
+            public string? SampleName { get; set; }
+        }
+
+        public class RandomObject2
+        {
+            public int SampleNumber { get; set; }
+        }
+    }
+}

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -508,7 +508,7 @@ namespace Mapster.Adapters
                 : arg.Settings;
 
             if (_source.Type == destinationType && shallowCopySettings.ShallowCopyForSameType == true
-                && notUsingDestinationValue)
+                && notUsingDestinationValue && rule == null)
                 exp = _source;
             else if (source is ConditionalExpression cond && mapping != null)
             {

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -503,8 +503,12 @@ namespace Mapster.Adapters
             var notUsingDestinationValue = mapping is not { UseDestinationValue: true };
             Expression exp;
 
-            if (_source.Type == destinationType && arg.Settings.ShallowCopyForSameType == true
-                && notUsingDestinationValue && rule == null)
+            var shallowCopySettings = _source.Type == destinationType
+                ? arg.Context.Config.GetMergedSettings(tuple, arg.MapType)
+                : arg.Settings;
+
+            if (_source.Type == destinationType && shallowCopySettings.ShallowCopyForSameType == true
+                && notUsingDestinationValue)
                 exp = _source;
             else if (source is ConditionalExpression cond && mapping != null)
             {

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -503,9 +503,14 @@ namespace Mapster.Adapters
             var notUsingDestinationValue = mapping is not { UseDestinationValue: true };
             Expression exp;
 
-            var shallowCopySettings = _source.Type == destinationType
-                ? arg.Context.Config.GetMergedSettings(tuple, arg.MapType)
-                : arg.Settings;
+            var shallowCopySettings = arg.Settings;
+            if (_source.Type == destinationType)
+            {
+                if (arg.Context.Config.RuleMap.ContainsKey(tuple))
+                    shallowCopySettings = arg.Context.Config.GetMergedSettings(tuple, arg.MapType);
+                else if (arg.Settings.ShallowCopyForSameType != true)
+                    shallowCopySettings = arg.Context.Config.GetMergedSettings(tuple, arg.MapType);
+            }
 
             if (_source.Type == destinationType && shallowCopySettings.ShallowCopyForSameType == true
                 && notUsingDestinationValue && rule == null)


### PR DESCRIPTION
## Summary
- When deciding same-type shallow copy, use `GetMergedSettings` for the current source/destination pair instead of only `arg.Settings` and skipping whenever an explicit rule exists.
- Allows `cfg.Default.ShallowCopyForSameType(true)` with `cfg.NewConfig<T,T>().ShallowCopyForSameType(false)` while preserving nested same-type shallow copy for types without an explicit override.

Fixes #938

## Test plan
- [x] `GlobalShallowCopy_WithPerTypeDeepCopy_ShouldRestoreViaMapToTarget`
- [x] `ParentDeepCopyOverride_ShouldNotDisableImplicitNestedShallowCopyForSameType`
- [ ] CI green on `development`