### PR TITLE
fix: honor per-type ShallowCopyForSameType override (#938)

### DIFF
--- a/src/Mapster.Tests/WhenPerTypeShallowCopyOverride.cs
+++ b/src/Mapster.Tests/WhenPerTypeShallowCopyOverride.cs
@@ -1,0 +1,105 @@
+using Mapster.Models;
+using MapsterMapper;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenPerTypeShallowCopyOverride
+    {
+        [TestMethod]
+        public void GlobalShallowCopy_WithPerTypeDeepCopy_ShouldRestoreViaMapToTarget()
+        {
+            var cfg = new TypeAdapterConfig();
+            cfg.RequireExplicitMapping = true;
+            cfg.Default.ShallowCopyForSameType(true);
+            cfg.Default.AvoidInlineMapping(true);
+
+            cfg.NewConfig<RandomObject2, RandomObject2>();
+            cfg.NewConfig<RandomObject1, RandomObject1>();
+
+            cfg.NewConfig<MyFailStuff, MyFailStuff>()
+                .ShallowCopyForSameType(false);
+
+            cfg.GetMergedSettings(new TypeTuple(typeof(MyFailStuff), typeof(MyFailStuff)), MapType.Map)
+                .ShallowCopyForSameType.ShouldBe(false);
+
+            cfg.Compile();
+
+            var mapper = new Mapper(cfg);
+
+            var dynamicStuff = new MyFailStuff();
+            dynamicStuff.Item1 = new RandomObject1();
+            dynamicStuff.Item1.SampleName = "SN1";
+            dynamicStuff.Item2 = new RandomObject2();
+            dynamicStuff.Item2.SampleNumber = 2;
+
+            var originalStuff = mapper.Map<MyFailStuff, MyFailStuff>(dynamicStuff);
+
+            dynamicStuff.Item1.SampleName = "SN1CHANGED";
+            dynamicStuff.Item2.SampleNumber = 3;
+
+            mapper.Map(originalStuff, dynamicStuff);
+
+            dynamicStuff.Item1.SampleName.ShouldBe("SN1");
+            dynamicStuff.Item2.SampleNumber.ShouldBe(2);
+            ReferenceEquals(dynamicStuff.Item1, originalStuff.Item1).ShouldBeFalse();
+            ReferenceEquals(dynamicStuff.Item2, originalStuff.Item2).ShouldBeFalse();
+        }
+
+        [TestMethod]
+        public void ParentDeepCopyOverride_ShouldNotDisableImplicitNestedShallowCopyForSameType()
+        {
+            var cfg = new TypeAdapterConfig();
+            cfg.Default.ShallowCopyForSameType(true);
+            cfg.NewConfig<Container, Container>()
+                .ShallowCopyForSameType(false);
+
+            cfg.Compile();
+
+            var src = new Container { Child = new NestedChild { Value = 1 } };
+            var dest = src.Adapt<Container>(cfg);
+
+            ReferenceEquals(src.Child, dest.Child).ShouldBeTrue();
+        }
+
+        public class Container
+        {
+            public NestedChild? Child { get; set; }
+        }
+
+        public class NestedChild
+        {
+            public int Value { get; set; }
+        }
+
+        public class MyFailStuff
+        {
+            public MyFailStuff()
+            {
+                CreateEmptyEntities();
+            }
+
+            public void CreateEmptyEntities()
+            {
+                Item1 ??= new RandomObject1();
+                Item2 ??= new RandomObject2();
+            }
+
+            public RandomObject1? Item1 { get; set; }
+
+            public RandomObject2? Item2 { get; set; }
+        }
+
+        public class RandomObject1
+        {
+            public string? SampleName { get; set; }
+        }
+
+        public class RandomObject2
+        {
+            public int SampleNumber { get; set; }
+        }
+    }
+}

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -503,7 +503,15 @@ namespace Mapster.Adapters
             var notUsingDestinationValue = mapping is not { UseDestinationValue: true };
             Expression exp;
 
-            if (_source.Type == destinationType && arg.Settings.ShallowCopyForSameType == true
+            var shallowCopy = arg.Settings.ShallowCopyForSameType;
+            if (_source.Type == destinationType)
+            {
+                var typeSettings = arg.Context.Config.GetMergedSettings(tuple, arg.MapType);
+                if (typeSettings.ShallowCopyForSameType != null)
+                    shallowCopy = typeSettings.ShallowCopyForSameType;
+            }
+
+            if (_source.Type == destinationType && shallowCopy == true
                 && notUsingDestinationValue && rule == null)
                 exp = _source;
             else if (source is ConditionalExpression cond && mapping != null)


### PR DESCRIPTION
## Summary
- Fixes #938 by resolving `ShallowCopyForSameType` from merged per-type settings when adapting same-type members, instead of always using the parent mapping's settings.
- A parent self-mapping with `ShallowCopyForSameType(false)` no longer suppresses global shallow-copy behavior for nested implicit same-type members.
- Explicit per-type `ShallowCopyForSameType(false)` overrides still force deep copy for self-mappings, including MapToTarget restore scenarios with ctor-initialized nested properties.

## Root cause
`CreateAdaptExpression` checked `arg.Settings.ShallowCopyForSameType` from the enclosing mapping context. When a parent type opted into deep copy, nested same-type members incorrectly inherited that setting even when their own merged settings/default should remain shallow.

## Test plan
- [x] `WhenPerTypeShallowCopyOverride.GlobalShallowCopy_WithPerTypeDeepCopy_ShouldRestoreViaMapToTarget`
- [x] `WhenPerTypeShallowCopyOverride.ParentDeepCopyOverride_ShouldNotDisableImplicitNestedShallowCopyForSameType`
- [x] Existing `WhenConfiguringMapping` shallow-copy tests pass