### PR TITLE
fix: support CompileProjection with Include on abstract types (#801)

### DIFF
--- a/src/Mapster.Tests/WhenIncludeDerivedClasses.cs
+++ b/src/Mapster.Tests/WhenIncludeDerivedClasses.cs
@@ -40,6 +40,37 @@ namespace Mapster.Tests
             ((BikeDto)dto[1]).Brand.ShouldBe("BMX");
         }
 
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/801
+        /// </summary>
+        [TestMethod]
+        public void CompileProjection_Including_Derived_Class()
+        {
+            TypeAdapterConfig<PocoA801, DtoA801>.NewConfig()
+                .Include<PocoDerived801, DtoDerived801>()
+                .CompileProjection();
+        }
+
+        public abstract class PocoA801
+        {
+            public int Id { get; set; }
+        }
+
+        public class PocoDerived801 : PocoA801
+        {
+            public int DerivedVal { get; set; }
+        }
+
+        public abstract class DtoA801
+        {
+            public int Id { get; set; }
+        }
+
+        public class DtoDerived801 : DtoA801
+        {
+            public int DerivedVal { get; set; }
+        }
+
         #region test classes
         public abstract class Vehicle
         {

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -540,6 +540,49 @@ namespace Mapster.Tests
         }
 
         /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/911
+        /// </summary>
+        [TestMethod]
+        public void NotSelfCreationTypeMappingInContainingClassWithoutError()
+        {
+            var jsonSource = new SourceClassWithJsonDocument911
+            {
+                Json = JsonDocument.Parse("{\"key\": \"value\"}")
+            };
+
+            var uriSource = new SourceClassWithUri911
+            {
+                Uri = new Uri("https://www.google.com/")
+            };
+
+            var jsonDest = jsonSource.Adapt<DestinationClassWithJsonDocument911>();
+            var uriDest = uriSource.Adapt<DestinationClassWithUri911>();
+
+            jsonDest.Json.RootElement.GetProperty("key").GetString().ShouldBe("value");
+            uriDest.Uri.ToString().ShouldBe("https://www.google.com/");
+        }
+
+        class SourceClassWithJsonDocument911
+        {
+            public required JsonDocument Json { get; init; }
+        }
+
+        class DestinationClassWithJsonDocument911
+        {
+            public required JsonDocument Json { get; init; }
+        }
+
+        class SourceClassWithUri911
+        {
+            public required Uri Uri { get; init; }
+        }
+
+        class DestinationClassWithUri911
+        {
+            public required Uri Uri { get; init; }
+        }
+
+        /// <summary>
         /// https://github.com/MapsterMapper/Mapster/issues/927
         /// </summary>
         [TestMethod]

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -219,9 +219,17 @@ namespace Mapster.Adapters
             //  Prop2 = convert(src.Prop2),
             //}
 
+            if (arg.MapType == MapType.Projection && arg.DestinationType.IsAbstract && arg.Settings.Includes.Count > 0)
+                return CreateIncludeProjectionExpression(source, arg);
+
             var exp = CreateInstantiationExpression(source, arg);
+            if (exp.NodeType == ExpressionType.Throw)
+                return null;
+
             var memberInit = exp as MemberInitExpression;
-            var newInstance = memberInit?.NewExpression ?? (NewExpression)exp;
+            var newInstance = memberInit?.NewExpression ?? exp as NewExpression;
+            if (newInstance == null)
+                return null;
             var contructorMembers = newInstance.GetAllMemberExpressionsMemberInfo().ToArray();
             ClassModel? classModel;
             ClassMapping? classConverter;
@@ -270,6 +278,36 @@ namespace Mapster.Adapters
             }
 
             return Expression.MemberInit(newInstance, lines);
+        }
+
+        static Expression CreateIncludeProjectionExpression(Expression source, CompileArgument arg)
+        {
+            Expression body = Expression.Default(arg.DestinationType);
+            foreach (var tuple in arg.Settings.Includes)
+            {
+                var itemTuple = tuple;
+                if (tuple.Source.IsOpenGenericType() && tuple.Destination.IsOpenGenericType())
+                {
+                    var genericArg = source.Type.GetGenericArguments();
+                    itemTuple = new TypeTuple(tuple.Source.MakeGenericType(genericArg), tuple.Destination.MakeGenericType(genericArg));
+                }
+
+                if (itemTuple.Source == arg.SourceType)
+                    continue;
+
+                if (!arg.SourceType.GetTypeInfo().IsAssignableFrom(itemTuple.Source.GetTypeInfo()))
+                    continue;
+
+                if (!arg.DestinationType.GetTypeInfo().IsAssignableFrom(itemTuple.Destination.GetTypeInfo()))
+                    continue;
+
+                var test = Expression.TypeIs(source, itemTuple.Source);
+                var cast = Expression.TypeAs(source, itemTuple.Source);
+                var mapped = CreateAdaptExpressionCore(cast!, itemTuple.Destination, arg);
+                body = Expression.Condition(test, mapped.To(arg.DestinationType, true), body);
+            }
+
+            return body;
         }
 
         protected override Expression CreateExpressionBody(Expression source, Expression? destination, CompileArgument arg)


### PR DESCRIPTION
## Summary

Fixes #801 and adds regression coverage for #911.

- **#801**: `CompileProjection()` on abstract base mappings with `.Include()` previously failed with `InvalidCastException` because inline projection tried to cast a `Throw`/`UnaryExpression` to `NewExpression`. The adapter now builds `TypeIs`-based conditional projection expressions for included derived types.
- **#911**: Adds tests verifying `JsonDocument` and `Uri` map correctly when nested inside containing classes (direct same-type mapping was already covered).

## Changes

- `ClassAdapter.CreateInlineExpression`: handle abstract destination + `Include` for projection; avoid invalid `NewExpression` cast when instantiation is impossible.
- `ClassAdapter.CreateIncludeProjectionExpression`: new helper mirroring runtime include redirect semantics for EF-translatable projection.
- Tests in `WhenIncludeDerivedClasses` and `WhenMappingRecordRegression`.

## Test plan

- [ ] CI passes on `development`
- [ ] `CompileProjection_Including_Derived_Class` compiles without exception
- [ ] `NotSelfCreationTypeMappingInContainingClassWithoutError` passes
- [ ] Existing include/projection tests remain green