### PR TITLE
fix: fall back to src-relative snk when SolutionDir is unset (#848)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,9 @@
 		<PackageIconUrl>https://cloud.githubusercontent.com/assets/5763993/26522718/d16f3e42-4330-11e7-9b78-f8c7402624e7.png</PackageIconUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<SignAssembly>true</SignAssembly>
-		<AssemblyOriginatorKeyFile>$(SolutionDir)/Mapster/Mapster.snk</AssemblyOriginatorKeyFile>
+		<!-- SolutionDir is not always set when building a project directly (e.g. dotnet test path/to/csproj). -->
+		<AssemblyOriginatorKeyFile Condition="'$(SolutionDir)' != '' and Exists('$(SolutionDir)Mapster/Mapster.snk')">$(SolutionDir)Mapster/Mapster.snk</AssemblyOriginatorKeyFile>
+		<AssemblyOriginatorKeyFile Condition="'$(AssemblyOriginatorKeyFile)' == '' and Exists('$(MSBuildThisFileDirectory)Mapster/Mapster.snk')">$(MSBuildThisFileDirectory)Mapster/Mapster.snk</AssemblyOriginatorKeyFile>
 		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 		<PackageTags>Mapper;AutoMapper;Fast;Mapping</PackageTags>
 		<PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

Fixes #848.

`Directory.Build.props` always referenced `$(SolutionDir)/Mapster/Mapster.snk`, but `SolutionDir` is not set when building/testing a single project directly (for example `dotnet test src/Mapster.DependencyInjection.Tests/Mapster.DependencyInjection.Tests.csproj`).

This adds a fallback to `$(MSBuildThisFileDirectory)Mapster/Mapster.snk`, which resolves correctly from `src/Directory.Build.props`.

## Changes

- `src/Directory.Build.props`: conditionally pick the signing key from `SolutionDir` when available, otherwise from the props file directory.

## Test plan

- [ ] CI passes on `development`
- [ ] `dotnet test src/Mapster.DependencyInjection.Tests/Mapster.DependencyInjection.Tests.csproj` succeeds without passing `-property:SolutionDir=...`
- [ ] Solution-wide builds still resolve the same signing key when `SolutionDir` is set