### PR TITLE
10.1.0 Fix and Improvements

### DIFF
--- a/src/Mapster.Core/Enums/MapType.cs
+++ b/src/Mapster.Core/Enums/MapType.cs
@@ -9,5 +9,6 @@ namespace Mapster
         MapToTarget = 2,
         Projection = 4,
         ApplyNullPropagation = 8,
+        CtorParam = 16,
     }
 }

--- a/src/Mapster.EF6/TypeAdapterBuilderExtensions.cs
+++ b/src/Mapster.EF6/TypeAdapterBuilderExtensions.cs
@@ -63,7 +63,7 @@ namespace Mapster
                                     .Select(s => s(src, model, arg))
                                     .FirstOrDefault(exp => exp != null))
                                 .Where(exp => exp != null)
-                                .Select(exp => Expression.Convert(exp, typeof(object)))
+                                .Select(exp => Expression.Convert(exp.Exp, typeof(object)))
                                 .ToArray();
                             if (getters.Length != keys.Length)
                                 throw new InvalidOperationException($"Cannot get key for sourceType={arg.SourceType.Name}, destinationType={arg.DestinationType.Name}");

--- a/src/Mapster.EF6/TypeAdapterBuilderExtensions.cs
+++ b/src/Mapster.EF6/TypeAdapterBuilderExtensions.cs
@@ -60,7 +60,7 @@ namespace Mapster
                             var getters = keys.Select(key => arg.DestinationType.GetProperty(key))
                                 .Select(prop => new PropertyModel(prop))
                                 .Select(model => arg.Settings.ValueAccessingStrategies
-                                    .Select(s => s(src, model, arg))
+                                    .Select(s => s((ResolverSourceInput)src, model, arg))
                                     .FirstOrDefault(exp => exp != null))
                                 .Where(exp => exp != null)
                                 .Select(exp => Expression.Convert(exp.Exp, typeof(object)))

--- a/src/Mapster.EFCore/TypeAdapterBuilderExtensions.cs
+++ b/src/Mapster.EFCore/TypeAdapterBuilderExtensions.cs
@@ -69,7 +69,7 @@ namespace Mapster
                                     .Select(s => s(src, model, arg))
                                     .FirstOrDefault(exp => exp != null))
                                 .Where(exp => exp != null)
-                                .Select(exp => Expression.Convert(exp, typeof(object)))
+                                .Select(exp => Expression.Convert(exp.Exp, typeof(object)))
                                 .ToArray();
                             if (getters.Length != keys.Length)
                                 throw new InvalidOperationException($"Cannot get key for sourceType={arg.SourceType.Name}, destinationType={arg.DestinationType.Name}");

--- a/src/Mapster.EFCore/TypeAdapterBuilderExtensions.cs
+++ b/src/Mapster.EFCore/TypeAdapterBuilderExtensions.cs
@@ -66,7 +66,7 @@ namespace Mapster
                             var getters = keys.Select(key => arg.DestinationType.GetProperty(key))
                                 .Select(prop => new PropertyModel(prop!))
                                 .Select(model => arg.Settings.ValueAccessingStrategies
-                                    .Select(s => s(src, model, arg))
+                                    .Select(s => s((ResolverSourceInput)src, model, arg))
                                     .FirstOrDefault(exp => exp != null))
                                 .Where(exp => exp != null)
                                 .Select(exp => Expression.Convert(exp.Exp, typeof(object)))

--- a/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
+++ b/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
@@ -139,23 +139,37 @@ namespace Mapster.Tests
             var config = new TypeAdapterConfig();
             config.Default.AddDestinationTransform(DestinationTransform.EmptyCollectionIfNull);
             config.ForDestinationType<DestinationFlattentData>()
-                .Ignore(x => x.Value);
+                .Ignore(x => x.Value)
+                .Ignore(x => x.Data);
             config.NewConfig<SourceFlattentInsaider, DestinationFlattentData>()
                 .ReMap(dest => dest, src => src.SrcData, true);
+            config.NewConfig<RemapMemberMappings, DestinationFlattentData>()
+                .ReMap(dest => dest.Data, src => src.Data);
+
+            var src = new SourceFlattentInsaider() { SrcData = new() { Value = "Hello", Data = 42 } };
+            var reMapSrc = new RemapMemberMappings { Data = 21, Value = "World" };
 
 
-            var src = new SourceFlattentInsaider() { SrcData = new() { Value = "Hello" } };
-
-            //var str = src.BuildAdapter(config).CreateMapExpression<DestinationFlattentData>();
 
             var result = src.Adapt<DestinationFlattentData>(config);
 
             result.Collection.ShouldBeNull();
             result.Value.ShouldBe("Hello");
-            
+            result.Data.ShouldBe(42);
+
+            var reMapResut = reMapSrc.Adapt<DestinationFlattentData>(config);
+
+            reMapResut.Data.ShouldBe(21);
+            reMapResut.Value.ShouldBe(default);
         }
 
         #region TestClasses
+
+        public class RemapMemberMappings
+        {
+            public int Data { get; set; }
+            public string Value { get; set; }
+        }
 
         public class DestinationFlattentData
         {

--- a/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
+++ b/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
@@ -133,6 +133,28 @@ namespace Mapster.Tests
         }
 
 
+        [TestMethod]
+        public void ReMapSettersIsWorked()
+        {
+            var config = new TypeAdapterConfig();
+            config.Default.AddDestinationTransform(DestinationTransform.EmptyCollectionIfNull);
+            config.ForDestinationType<DestinationFlattentData>()
+                .Ignore(x => x.Value);
+            config.NewConfig<SourceFlattentInsaider, DestinationFlattentData>()
+                .ReMap(dest => dest, src => src.SrcData, true);
+
+
+            var src = new SourceFlattentInsaider() { SrcData = new() { Value = "Hello" } };
+
+            //var str = src.BuildAdapter(config).CreateMapExpression<DestinationFlattentData>();
+
+            var result = src.Adapt<DestinationFlattentData>(config);
+
+            result.Collection.ShouldBeNull();
+            result.Value.ShouldBe("Hello");
+            
+        }
+
         #region TestClasses
 
         public class DestinationFlattentData

--- a/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
+++ b/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
@@ -113,13 +113,23 @@ namespace Mapster.Tests
             config.NewConfig<SourceFlattentInsaider, DestinationFlattentData>()
                 .MapUsing(dest=> dest, src => src.SrcData, cfg =>
                 {
-                    cfg.SkipDestinationTransforms();
+                    cfg.SkipDestinationTransforms()
+                    .ReConfigurate()
+                    .Map(dest=>dest.Data, src => 42)
+                    .MapUsing(dest => dest.Collection, src => src.Collection, cfg =>
+                    {
+                        cfg
+                        .SkipDestinationTransforms();
+                    })
+                    ;
                 });
 
             var src = new SourceFlattentInsaider() { SrcData = new() { Value = "Hello" } };
 
             var result = src.Adapt<DestinationFlattentData>(config);
 
+            result.Collection.ShouldBeNull();
+            result.Data.ShouldBe(42);
         }
 
 

--- a/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
+++ b/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
@@ -2,6 +2,7 @@
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Mapster.Tests
 {
@@ -163,7 +164,86 @@ namespace Mapster.Tests
             reMapResut.Value.ShouldBe(default);
         }
 
+        [TestMethod]
+        public void ApplyPropagantionUsingDeepSrcAnalize()
+        {
+            var config = new TypeAdapterConfig();
+
+            config.NewConfig<Source1004, Destination1004>()
+                .Map(dest => dest.ProductNames, src => src.Products.Select(x => x.Name).ToArray());
+
+            config.NewConfig<Source1004, DestinationCtor1004>()
+                .Map(dest => dest.ProductNames, src => src.Products.Select(x => x.Name).ToArray());
+
+            config.NewConfig<NullableStrings, NullableStringsDest>()
+                .Map(dest => dest.Result, src => $"{src.Value1.ToString()}");
+
+            config.NewConfig<NullableStrings, NullableStringsDestCtor>()
+                .Map(dest => dest.Result, src => $"{src.Value1.ToString()}");
+
+            var src = new Source1004();
+            var srcStrings = new NullableStrings();
+
+            //var str = src.BuildAdapter(config).CreateMapExpression<DestinationCtor1004>();
+            //var str2 = src.BuildAdapter(config).CreateMapExpression<NullableStringsDestCtor>();
+
+            Should.NotThrow(() =>
+            {
+                src.Adapt<Destination1004>(config);
+                src.Adapt<DestinationCtor1004>(config);
+
+                srcStrings.Adapt<NullableStringsDest>(config);
+                srcStrings.Adapt<NullableStringsDestCtor>(config);
+            });
+        }
+
         #region TestClasses
+
+        class Source1004
+        {
+            public Product1004[]? Products { get; set; }
+        }
+
+        class Product1004
+        {
+            public required string Name { get; set; }
+        }
+
+        class Destination1004
+        {
+            public string[]? ProductNames { get; set; }
+        }
+
+        class DestinationCtor1004
+        {
+            public DestinationCtor1004(string[]? productNames)
+            {
+                ProductNames = productNames;
+            }
+
+            public string[]? ProductNames { get; }
+        }
+
+        public class NullableStrings
+        {
+            public string Value1 { get; set; }
+
+            public string Value2 { get; set; }
+        }
+
+        public class NullableStringsDest
+        {
+            public string Result { get; set; }
+        }
+        public class NullableStringsDestCtor
+        {
+            public NullableStringsDestCtor(string result)
+            {
+                Result = result;
+            }
+
+            public string Result { get;}
+        }
 
         public class RemapMemberMappings
         {

--- a/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
+++ b/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
@@ -105,7 +105,44 @@ namespace Mapster.Tests
             result.Data.ShouldBe(35);
         }
 
+        [TestMethod]
+        public void ExtraSourceUsingCustomConfig()
+        {
+            var config = new TypeAdapterConfig();
+            config.Default.AddDestinationTransform(DestinationTransform.EmptyCollectionIfNull);
+            config.NewConfig<SourceFlattentInsaider, DestinationFlattentData>()
+                .MapUsing(dest=> dest, src => src.SrcData, cfg =>
+                {
+                    cfg.SkipDestinationTransforms();
+                });
+
+            var src = new SourceFlattentInsaider() { SrcData = new() { Value = "Hello" } };
+
+            var result = src.Adapt<DestinationFlattentData>(config);
+
+        }
+
+
         #region TestClasses
+
+        public class DestinationFlattentData
+        {
+            public int Data { get; set; }
+            public string Value { get; set; }
+            public List<string> Collection { get; set; }
+        }
+
+        public class SourceFlattentData
+        {
+            public int Data { get; set; }
+            public string Value { get; set; }
+            public List<string> Collection { get; set; }
+        }
+
+        public class SourceFlattentInsaider
+        {
+            public SourceFlattentData SrcData { get; set; }
+        }
 
         public class NullableIntCtorParam
         {

--- a/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
+++ b/src/Mapster.Tests/WhenMapUsingOverrideTypesSettings.cs
@@ -82,7 +82,40 @@ namespace Mapster.Tests
             resultCDInsaiderReconfig.Data.ShouldBe(35);
         }
 
+        [TestMethod]
+        public void CustomDefaultValueIsWorkedWhenUsingAsCtorParam()
+        {
+            var config = new TypeAdapterConfig();
+
+            config.ForDestinationType<int?>()
+                .DefaultValue(x => 42);
+
+            config.
+               NewConfig<NullableIntInsaider, NullableIntCtorParam>()
+               .MapUsing(dest => dest.Data, src => src.Data, cfg =>
+               {
+                   cfg.ReConfigurate()
+                   .DefaultValue(x => 35);
+               });
+
+            var src = new NullableIntInsaider() { Data = null };
+
+            var result = src.Adapt<NullableIntCtorParam>(config);
+
+            result.Data.ShouldBe(35);
+        }
+
         #region TestClasses
+
+        public class NullableIntCtorParam
+        {
+            public NullableIntCtorParam(int? data)
+            {
+                Data = data;
+            }
+            public int? Data { get; }
+        }
+
 
         public class NullableIntInsaider
         {

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -208,7 +208,7 @@ namespace Mapster.Adapters
             /// Not create destination is abstract type if source is null
             if (arg.DestinationType.IsAbstract)
                 blocks.Add(Expression.IfThen(Expression.Equal(source, Expression.Constant(null, arg.SourceType)), 
-                    Expression.Return(label, Expression.Default(arg.DestinationType))));
+                    Expression.Return(label, arg.DestinationType.CreateDefault(arg))));
 
             //new TDest();
             Expression transformedSource = source;

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -388,6 +388,9 @@ namespace Mapster.Adapters
             if (exp == null)
                 return null;
 
+            if(arg.MapType == MapType.CtorParam)
+                return exp;
+
             //projection null is handled by EF
             if (arg.MapType != MapType.Projection)
                 exp = source.NotNullReturn(exp,arg);
@@ -448,9 +451,10 @@ namespace Mapster.Adapters
             }
         }
 
-        internal static Expression CreateAdaptExpressionCore(Expression source, Type destinationType, CompileArgument arg, MemberMapping? mapping = null, Expression? destination = null)
+        internal static Expression CreateAdaptExpressionCore(Expression source, Type destinationType, CompileArgument arg, MemberMapping? mapping = null, Expression? destination = null, MapType? mapTypeCtor = null)
         {
-            var mapType = arg.MapType == MapType.MapToTarget && destination == null ? MapType.Map :
+            var mapType = mapTypeCtor != null ? mapTypeCtor.Value:
+                arg.MapType == MapType.MapToTarget && destination == null ? MapType.Map :
                 mapping?.UseDestinationValue == true ? MapType.MapToTarget :
                 arg.MapType;
             var extraParams = new HashSet<ParameterExpression>();

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -217,8 +217,9 @@ namespace Mapster.Adapters
 
             if (resolver?.Settings != null)
             {
-               if(resolver.Settings.RemapExtraSource.GetValueOrDefault() 
-                    || resolver.Settings.ReMapDestination.Contains(destinationMember.Name))
+               if(resolver.Settings.ReMapExtraSource.GetValueOrDefault() 
+                    || resolver.Settings.ReMapDestination.Contains(destinationMember.Name)
+                    || arg.Settings.ReMapDestinationMembers.Contains(destinationMember.Name))
                     return false;
             }
                 

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -275,7 +275,7 @@ namespace Mapster.Adapters
                     }
                     else
                        getter = member.Getter
-                            .ApplyNullPropagationFromCtor(CreateAdaptExpressionCore(member.Getter, member.DestinationMember.Type, arg, member), arg);
+                            .ApplyNullPropagationFromCtor(CreateAdaptExpressionCore(member.Getter, member.DestinationMember.Type, arg, member), arg, member);
 
                     
 

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -222,7 +222,8 @@ namespace Mapster.Adapters
             var members = classConverter.Members;
 
             var arguments = new List<Expression>();
-            arg.Context.NullChecks.UnionWith(members.Where(x => x.Getter != null).Select(x => (x.Getter, arg)));
+            // ReadyToCleanUp
+            // arg.Context.NullChecks.UnionWith(members.Where(x => x.Getter != null).Select(x => (x.Getter, arg)));
             foreach (var member in members)
             {
                 var parameterInfo = (ParameterInfo)member.DestinationMember.Info!;
@@ -268,7 +269,7 @@ namespace Mapster.Adapters
                     }
                     else
                        getter = member.Getter
-                            .ApplyNullPropagationFromCtor(CreateAdaptExpressionCore(member.Getter, member.DestinationMember.Type, arg, member), arg, member);
+                            .ApplyNullPropagationFromCtor(CreateAdaptExpressionCore(member.Getter, member.DestinationMember.Type, arg, member,mapTypeCtor:MapType.CtorParam), arg, member);
 
                     
 

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -39,16 +39,17 @@ namespace Mapster.Adapters
                 var resolvers = arg.Settings.ValueAccessingStrategies.AsEnumerable();
                 if (arg.Settings.IgnoreNonMapped == true)
                     resolvers = resolvers.Where(ValueAccessingStrategy.CustomResolvers.Contains);
-                var getter = (from fn in resolvers
+                var resolver = (from fn in resolvers
                         from src in sources
                         select fn(src, destinationMember, arg))
                     .FirstOrDefault(result => result != null);
-                if(getter is MemberExpression mem && mem?.Expression?.Type == source.Type)
+                var getter = resolver?.Exp;
+                var overideSettings = resolver?.Settings;
+
+                if (getter is MemberExpression mem && mem?.Expression?.Type == source.Type)
                 {
                     getter = Expression.PropertyOrField(source, mem.Member.Name);
                 }
-
-              var   test = resolvers.Where(ValueAccessingStrategy.CustomResolvers.Contains);
 
                 if (arg.MapType == MapType.Projection && getter != null)
                 {
@@ -72,7 +73,7 @@ namespace Mapster.Adapters
                     getter = (from fn in resolvers
                               from src in sources
                               select fn(src, destinationMember, arg))
-                    .FirstOrDefault(result => result != null);
+                    .FirstOrDefault(result => result != null)?.Exp;
                 }
 
 
@@ -104,14 +105,9 @@ namespace Mapster.Adapters
 
                 }
 
-
                 var nextIgnore = arg.Settings.Ignore.Next((ParameterExpression)source, (ParameterExpression?)destination, destinationMember.Name);
                 var nextResolvers = arg.Settings.Resolvers.Next(arg.Settings.Ignore, (ParameterExpression)source, destinationMember.Name)
                     .ToList();
-
-                var overideSettings = arg.Settings.Resolvers
-                    .Where(x => x.DestinationMemberName == destinationMember.Name && x.OvverideSettings != null)
-                    .Select(x=>x.OvverideSettings).FirstOrDefault();
 
                 var propertyModel = new MemberMapping
                 {

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -25,12 +25,9 @@ namespace Mapster.Adapters
             if (arg.Settings.IgnoreNonMapped == true)
                 IgnoreNonMapped(classModel,arg);
           
-            var sources = new List<Expression> {source};
+            var sources = new List<ResolverSourceInput> {new ResolverSourceInput(source)};
             sources.AddRange(
-                arg.Settings.ExtraSources.Select(src =>
-                    src is LambdaExpression lambda 
-                        ? lambda.Apply(arg.MapType, source) 
-                        : ExpressionEx.PropertyOrFieldPath(source, (string)src)));
+                arg.Settings.ExtraSources.Select(src => ResolverSourceInput.ConvertFrom(src,source,arg)));
             foreach (var destinationMember in destinationMembers)
             {
                 if (ProcessIgnores(arg, destinationMember, out var ignore) && !ctorMapping)

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -43,9 +43,10 @@ namespace Mapster.Adapters
                 var getter = resolver?.Exp;
                 var overideSettings = resolver?.Settings;
 
+                // ReadyToCleanUp
                 // source in overideSettings is not source in this context 
-                if (overideSettings != null && getter != null)
-                    getter = ReplaceOvverideExpressionParam.Replace(getter, source);
+                //  if (overideSettings != null && getter != null)
+                //  getter = ReplaceOvverideExpressionParam.Replace(getter, source);
 
                 if (arg.MapType == MapType.Projection && getter != null)
                 {

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -137,9 +137,9 @@ namespace Mapster.Adapters
                 }
                 if (getter != null)
                 {
-                    propertyModel.Getter = arg.MapType == MapType.Projection 
-                        ? getter 
-                        : getter.ApplyPropertyNullPropagation(arg);
+                    propertyModel.Getter = arg.MapType == MapType.Projection || ctorMapping
+                        ? getter
+                        : getter.ApplyPropertyNullPropagation(arg, source);
                     properties.Add(propertyModel);
                 }
                 else

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -43,10 +43,9 @@ namespace Mapster.Adapters
                 var getter = resolver?.Exp;
                 var overideSettings = resolver?.Settings;
 
-                if (getter is MemberExpression mem && mem?.Expression?.Type == source.Type)
-                {
-                    getter = Expression.PropertyOrField(source, mem.Member.Name);
-                }
+                // source in overideSettings is not source in this context 
+                if (overideSettings != null && getter != null)
+                    getter = ReplaceOvverideExpressionParam.Replace(getter, source);
 
                 if (arg.MapType == MapType.Projection && getter != null)
                 {

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -30,7 +30,7 @@ namespace Mapster.Adapters
                 arg.Settings.ExtraSources.Select(src => ResolverSourceInput.ConvertFrom(src,source,arg)));
             foreach (var destinationMember in destinationMembers)
             {
-                if (ProcessIgnores(arg, destinationMember, out var ignore) && !ctorMapping)
+                if (!destinationMember.ShouldMapMember(arg, MemberSide.Destination))
                     continue;
 
                 var resolvers = arg.Settings.ValueAccessingStrategies.AsEnumerable();
@@ -42,6 +42,9 @@ namespace Mapster.Adapters
                     .FirstOrDefault(result => result != null);
                 var getter = resolver?.Exp;
                 var overideSettings = resolver?.Settings;
+
+                if (ProcessIgnores(arg, destinationMember,out var ignore, resolver) && !ctorMapping)
+                    continue;
 
                 // ReadyToCleanUp
                 // source in overideSettings is not source in this context 
@@ -206,10 +209,19 @@ namespace Mapster.Adapters
 
         protected static bool ProcessIgnores(
             CompileArgument arg,
-            IMemberModel destinationMember,
-            out IgnoreDictionary.IgnoreItem ignore)
+            IMemberModel destinationMember, 
+            out IgnoreDictionary.IgnoreItem ignore,
+            ResolverResult? resolver = null)
         {
             ignore = new IgnoreDictionary.IgnoreItem();
+
+            if (resolver?.Settings != null)
+            {
+               if(resolver.Settings.RemapExtraSource.GetValueOrDefault() 
+                    || resolver.Settings.ReMapDestination.Contains(destinationMember.Name))
+                    return false;
+            }
+                
             if (!destinationMember.ShouldMapMember(arg, MemberSide.Destination))
                 return true;
 

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -282,7 +282,7 @@ namespace Mapster.Adapters
 
         static Expression CreateIncludeProjectionExpression(Expression source, CompileArgument arg)
         {
-            Expression body = Expression.Default(arg.DestinationType);
+            Expression body = arg.DestinationType.CreateDefault(arg);
             foreach (var tuple in arg.Settings.Includes)
             {
                 var itemTuple = tuple;

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -253,8 +253,8 @@ namespace Mapster.Adapters
                 if (member.UseDestinationValue)
                     return null;
 
-                if (!arg.Settings.Resolvers.Any(r => r.DestinationMemberName == member.DestinationMember.Name) 
-                    && member.Getter is MemberExpression memberExp && contructorMembers.Contains(memberExp.Member))
+                if (!arg.Settings.Resolvers.Any(r => r.DestinationMemberName == member.DestinationMember.Name)
+                    && contructorMembers.Select(x => x.Name).Contains(member.DestinationMember.Name, new MapsterStringComparer()))
                     continue;
 
                 if (member.DestinationMember.SetterModifier == AccessModifier.None)

--- a/src/Mapster/Compile/CompileContext.cs
+++ b/src/Mapster/Compile/CompileContext.cs
@@ -12,7 +12,9 @@ namespace Mapster
         public int? MaxDepth { get; set; }
         public int Depth { get; set; }
         public HashSet<ParameterExpression> ExtraParameters { get; } = new();
-        public HashSet<(Expression param, CompileArgument arg)> NullChecks { get; } = new();
+
+        // ReadyToCleanUp
+       // public HashSet<(Expression param, CompileArgument arg)> NullChecks { get; } = new();
 
         internal bool IsSubFunction()
         {

--- a/src/Mapster/Models/ExtraSourceModel.cs
+++ b/src/Mapster/Models/ExtraSourceModel.cs
@@ -1,0 +1,10 @@
+﻿using System.Linq.Expressions;
+
+namespace Mapster.Models
+{
+    public record ExtraSourceModel(object Src, OverrideTypesSettings? Settings = null)
+    {
+        public static explicit operator ExtraSourceModel(Expression src) => new ExtraSourceModel(src);
+        public static explicit operator ExtraSourceModel(string src) => new ExtraSourceModel(src);
+    }
+}

--- a/src/Mapster/Models/InvokerModel.cs
+++ b/src/Mapster/Models/InvokerModel.cs
@@ -1,5 +1,6 @@
-﻿using System.Linq.Expressions;
-using Mapster.Utils;
+﻿using Mapster.Utils;
+using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace Mapster.Models
 {
@@ -45,6 +46,20 @@ namespace Mapster.Models
             return IsChildPath
                 ? Condition?.Body
                 : Condition?.Apply(mapType, exp);
+        }
+    }
+
+    public class InvokerModelApplyComparer : IEqualityComparer<InvokerModel>
+    {
+        public bool Equals(InvokerModel? x, InvokerModel? y)
+        {
+            if (x is null || y is null) return false;
+            return string.Equals(x.DestinationMemberName, y.DestinationMemberName, System.StringComparison.InvariantCulture);
+        }
+
+        public int GetHashCode(InvokerModel obj)
+        {
+            return obj?.DestinationMemberName?.GetHashCode() ?? 0;
         }
     }
 }

--- a/src/Mapster/Models/InvokerModel.cs
+++ b/src/Mapster/Models/InvokerModel.cs
@@ -32,20 +32,20 @@ namespace Mapster.Models
             };
         }
 
-        public Expression GetInvokingExpression(Expression exp, MapType mapType = MapType.Map)
+        public Expression GetInvokingExpression(Expression exp, MapType mapType = MapType.Map, bool isExtraParam = false)
         {
             if (IsChildPath)
                 return Invoker!.Body;
             return SourceMemberName != null
                 ? ExpressionEx.PropertyOrFieldPath(exp, SourceMemberName)
-                : Invoker!.Apply(mapType, exp);
+                : isExtraParam ? Invoker!.ApplyExtraSources(mapType, exp) : Invoker!.Apply(mapType, exp);
         }
 
-        public Expression? GetConditionExpression(Expression exp, MapType mapType = MapType.Map)
+        public Expression? GetConditionExpression(Expression exp, MapType mapType = MapType.Map, bool isExtraParam = false)
         {
             return IsChildPath
                 ? Condition?.Body
-                : Condition?.Apply(mapType, exp);
+                : isExtraParam ? Condition?.ApplyExtraSources(mapType, exp) : Condition?.Apply(mapType, exp);
         }
     }
 

--- a/src/Mapster/Settings/ValueAccessingStrategy.cs
+++ b/src/Mapster/Settings/ValueAccessingStrategy.cs
@@ -28,7 +28,7 @@ namespace Mapster
         {
             var source = srcInput.Src;
             var config = source.Type == arg.SourceType ? arg.Settings : arg.Context.Config.GetMergedSettings(new TypeTuple(source.Type, arg.DestinationType),arg.MapType);
-            var resolvers = config.Resolvers;
+            var resolvers = srcInput.Settings != null ? srcInput.Settings.ApplyResolversOnly(config) : config.Resolvers;
             if (resolvers.Count == 0)
                 return null;
             TypeAdapterSettings? customSettings = null;

--- a/src/Mapster/Settings/ValueAccessingStrategy.cs
+++ b/src/Mapster/Settings/ValueAccessingStrategy.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Mapster.Models;
 using Mapster.Utils;
-using ValueAccess = System.Func<System.Linq.Expressions.Expression, Mapster.Models.IMemberModel, Mapster.CompileArgument, Mapster.ResolverResult?>;
+using ValueAccess = System.Func<Mapster.ResolverSourceInput, Mapster.Models.IMemberModel, Mapster.CompileArgument, Mapster.ResolverResult?>;
 
 namespace Mapster
 {
@@ -24,8 +24,9 @@ namespace Mapster
             CustomResolverForDictionary,
         };
 
-        private static ResolverResult? CustomResolverFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? CustomResolverFn(ResolverSourceInput srcInput, IMemberModel destinationMember, CompileArgument arg)
         {
+            var source = srcInput.Src;
             var config = source.Type == arg.SourceType ? arg.Settings : arg.Context.Config.GetMergedSettings(new TypeTuple(source.Type, arg.DestinationType),arg.MapType);
             var resolvers = config.Resolvers;
             if (resolvers.Count == 0)
@@ -72,11 +73,12 @@ namespace Mapster
 
             if (getter == null)
                 return null;
-            return new ResolverResult(getter,customSettings);
+            return new ResolverResult(getter,(OverrideTypesSettings?)customSettings);
         }
 
-        private static ResolverResult? PropertyOrFieldFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? PropertyOrFieldFn(ResolverSourceInput srcInput, IMemberModel destinationMember, CompileArgument arg)
         {
+            var source = srcInput.Src;
             var members = source.Type.GetFieldsAndProperties(true);
             var strategy = arg.Settings.NameMatchingStrategy;
             var destinationMemberName = destinationMember.GetMemberName(MemberSide.Destination, arg.Settings.GetMemberNames, strategy.DestinationMemberNameConverter, arg);
@@ -93,8 +95,9 @@ namespace Mapster
 
         }
 
-        private static ResolverResult? GetMethodFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? GetMethodFn(ResolverSourceInput srcInput, IMemberModel destinationMember, CompileArgument arg)
         {
+            var source = srcInput.Src;
             if (arg.MapType == MapType.Projection)
                 return null;
             var strategy = arg.Settings.NameMatchingStrategy;
@@ -107,8 +110,9 @@ namespace Mapster
             return new ResolverResult( Expression.Call(source, getMethod),null);
         }
 
-        private static ResolverResult? FlattenMemberFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? FlattenMemberFn(ResolverSourceInput srcInput, IMemberModel destinationMember, CompileArgument arg)
         {
+            var source = srcInput.Src;
             var strategy = arg.Settings.NameMatchingStrategy;
             var destinationMemberName = destinationMember.GetMemberName(MemberSide.Destination, arg.Settings.GetMemberNames, strategy.DestinationMemberNameConverter, arg);
             var resolver = GetDeepFlattening(source, destinationMemberName, arg);
@@ -192,8 +196,9 @@ namespace Mapster
             }
         }
 
-        private static ResolverResult? DictionaryFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? DictionaryFn(ResolverSourceInput srcInput, IMemberModel destinationMember, CompileArgument arg)
         {
+            var source = srcInput.Src;
             var dictType = source.Type.GetDictionaryType();
             if (dictType == null)
                 return null;
@@ -220,8 +225,9 @@ namespace Mapster
             }
         }
 
-        private static ResolverResult? CustomResolverForDictionaryFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? CustomResolverForDictionaryFn(ResolverSourceInput srcInput, IMemberModel destinationMember, CompileArgument arg)
         {
+            var source = srcInput.Src;
             var config = arg.Settings;
             var resolvers = config.Resolvers;
             if (resolvers.Count == 0)
@@ -257,5 +263,17 @@ namespace Mapster
         }
     }
 
-    public record ResolverResult(Expression Exp , TypeAdapterSettings? Settings = null);
+    public record ResolverResult(Expression Exp , OverrideTypesSettings? Settings = null);
+    public record ResolverSourceInput(Expression Src, OverrideTypesSettings? Settings = null)
+    {
+        public static explicit operator ResolverSourceInput(Expression src) => new ResolverSourceInput(src);
+        public static explicit operator ResolverSourceInput(ParameterExpression src) => new ResolverSourceInput(src);
+        public static ResolverSourceInput ConvertFrom(ExtraSourceModel extraSource,Expression source, CompileArgument arg)
+        {
+            if (extraSource.Src is LambdaExpression lambda)
+                return new ResolverSourceInput(lambda.Apply(arg.MapType, source), extraSource.Settings);
+            else
+                return new ResolverSourceInput(ExpressionEx.PropertyOrFieldPath(source, (string)extraSource.Src), extraSource.Settings);
+        }
+    };
 }

--- a/src/Mapster/Settings/ValueAccessingStrategy.cs
+++ b/src/Mapster/Settings/ValueAccessingStrategy.cs
@@ -91,7 +91,7 @@ namespace Mapster
             if (resolver == null)
                 return null;
             else
-                return new ResolverResult(resolver, null);
+                return new ResolverResult(resolver, srcInput.Settings != null ? srcInput.Settings.CloneOnlySkipSettings() : null);
 
         }
 

--- a/src/Mapster/Settings/ValueAccessingStrategy.cs
+++ b/src/Mapster/Settings/ValueAccessingStrategy.cs
@@ -44,7 +44,7 @@ namespace Mapster
                 if(resolver.OvverideSettings != null && customSettings == null)
                     customSettings = resolver.OvverideSettings;
 
-                var invoke = resolver.GetInvokingExpression(source, arg.MapType);
+                var invoke = resolver.GetInvokingExpression(source, arg.MapType, customSettings != null);
                 var condition = resolver.GetConditionExpression(source, arg.MapType);
                 if (condition == null)
                 {

--- a/src/Mapster/Settings/ValueAccessingStrategy.cs
+++ b/src/Mapster/Settings/ValueAccessingStrategy.cs
@@ -271,7 +271,7 @@ namespace Mapster
         public static ResolverSourceInput ConvertFrom(ExtraSourceModel extraSource,Expression source, CompileArgument arg)
         {
             if (extraSource.Src is LambdaExpression lambda)
-                return new ResolverSourceInput(lambda.Apply(arg.MapType, source), extraSource.Settings);
+                return new ResolverSourceInput(lambda.ApplyExtraSources(arg.MapType, source), extraSource.Settings);
             else
                 return new ResolverSourceInput(ExpressionEx.PropertyOrFieldPath(source, (string)extraSource.Src), extraSource.Settings);
         }

--- a/src/Mapster/Settings/ValueAccessingStrategy.cs
+++ b/src/Mapster/Settings/ValueAccessingStrategy.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Mapster.Models;
 using Mapster.Utils;
-using ValueAccess = System.Func<System.Linq.Expressions.Expression, Mapster.Models.IMemberModel, Mapster.CompileArgument, System.Linq.Expressions.Expression?>;
+using ValueAccess = System.Func<System.Linq.Expressions.Expression, Mapster.Models.IMemberModel, Mapster.CompileArgument, Mapster.ResolverResult?>;
 
 namespace Mapster
 {
@@ -24,12 +24,13 @@ namespace Mapster
             CustomResolverForDictionary,
         };
 
-        private static Expression? CustomResolverFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? CustomResolverFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
         {
             var config = source.Type == arg.SourceType ? arg.Settings : arg.Context.Config.GetMergedSettings(new TypeTuple(source.Type, arg.DestinationType),arg.MapType);
             var resolvers = config.Resolvers;
             if (resolvers.Count == 0)
                 return null;
+            TypeAdapterSettings? customSettings = null;
 
             var invokes = new List<Tuple<Expression, Expression>>();
 
@@ -38,6 +39,9 @@ namespace Mapster
             {
                 if (!destinationMember.Name.Equals(resolver.DestinationMemberName, StringComparison.InvariantCultureIgnoreCase))
                     continue;
+
+                if(resolver.OvverideSettings != null && customSettings == null)
+                    customSettings = resolver.OvverideSettings;
 
                 var invoke = resolver.GetInvokingExpression(source, arg.MapType);
                 var condition = resolver.GetConditionExpression(source, arg.MapType);
@@ -66,22 +70,30 @@ namespace Mapster
                 }
             }
 
-            return getter;
+            if (getter == null)
+                return null;
+            return new ResolverResult(getter,customSettings);
         }
 
-        private static Expression? PropertyOrFieldFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? PropertyOrFieldFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
         {
             var members = source.Type.GetFieldsAndProperties(true);
             var strategy = arg.Settings.NameMatchingStrategy;
             var destinationMemberName = destinationMember.GetMemberName(MemberSide.Destination, arg.Settings.GetMemberNames, strategy.DestinationMemberNameConverter, arg);
-            return members
+            var resolver = members
                 .Where(member => member.ShouldMapMember(arg, MemberSide.Source))
                 .Where(member => member.GetMemberName(MemberSide.Source, arg.Settings.GetMemberNames, strategy.SourceMemberNameConverter, arg) == destinationMemberName)
                 .Select(member => member.GetExpression(source))
                 .FirstOrDefault();
+
+            if (resolver == null)
+                return null;
+            else
+                return new ResolverResult(resolver, null);
+
         }
 
-        private static Expression? GetMethodFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? GetMethodFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
         {
             if (arg.MapType == MapType.Projection)
                 return null;
@@ -92,14 +104,17 @@ namespace Mapster
                 return null;
             if (getMethod.Name == "GetType" && destinationMember.Type != typeof(Type))
                 return null;
-            return Expression.Call(source, getMethod);
+            return new ResolverResult( Expression.Call(source, getMethod),null);
         }
 
-        private static Expression? FlattenMemberFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? FlattenMemberFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
         {
             var strategy = arg.Settings.NameMatchingStrategy;
             var destinationMemberName = destinationMember.GetMemberName(MemberSide.Destination, arg.Settings.GetMemberNames, strategy.DestinationMemberNameConverter, arg);
-            return GetDeepFlattening(source, destinationMemberName, arg);
+            var resolver = GetDeepFlattening(source, destinationMemberName, arg);
+            if(resolver == null)
+                return null;
+            return new ResolverResult(resolver, null);
         }
 
         private static Expression? GetDeepFlattening(Expression source, string propertyName, CompileArgument arg)
@@ -177,7 +192,7 @@ namespace Mapster
             }
         }
 
-        private static Expression? DictionaryFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? DictionaryFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
         {
             var dictType = source.Type.GetDictionaryType();
             if (dictType == null)
@@ -192,18 +207,20 @@ namespace Mapster
                 var method = typeof(MapsterHelper).GetMethods()
                     .First(m => m.Name == nameof(MapsterHelper.FlexibleGet) && m.GetParameters()[0].ParameterType.Name == dictType.Name)
                     .MakeGenericMethod(args[1]);
-                return Expression.Call(method, source.To(dictType), key, ExpressionEx.GetNameConverterExpression(strategy.SourceMemberNameConverter));
+                var resolver = Expression.Call(method, source.To(dictType), key, ExpressionEx.GetNameConverterExpression(strategy.SourceMemberNameConverter));
+                return new ResolverResult(resolver);
             }
             else
             {
                 var method = typeof(MapsterHelper).GetMethods()
                     .First(m => m.Name == nameof(MapsterHelper.GetValueOrDefault) && m.GetParameters()[0].ParameterType.Name == dictType.Name)
                     .MakeGenericMethod(args);
-                return Expression.Call(method, source.To(dictType), key);
+                var resolver =  Expression.Call(method, source.To(dictType), key);
+                return new ResolverResult(resolver);
             }
         }
 
-        private static Expression? CustomResolverForDictionaryFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
+        private static ResolverResult? CustomResolverForDictionaryFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
         {
             var config = arg.Settings;
             var resolvers = config.Resolvers;
@@ -236,7 +253,9 @@ namespace Mapster
             }
             if (lastCondition != null)
                 getter = Expression.Condition(lastCondition, getter!, getter!.Type.CreateDefault(arg));
-            return getter;
+            return new ResolverResult(getter);
         }
     }
+
+    public record ResolverResult(Expression Exp , TypeAdapterSettings? Settings = null);
 }

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -495,7 +495,7 @@ namespace Mapster
 
                 var condition = Expression.TypeIs(tempDest, destinationType);
                 UnaryExpression ifTrue = Expression.Convert(tempDest, destinationType);
-                DefaultExpression ifFalse = Expression.Default(destinationType);
+                Expression ifFalse = destinationType.CreateDefault(arg);
 
                 ConditionalExpression conditionalExpr = Expression.Condition(condition, ifTrue, ifFalse);
                 blockbody.Add(conditionalExpr);

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -431,7 +431,7 @@ namespace Mapster
             var invoker = Expression.Lambda(source.Body, Expression.Parameter(typeof (object)));
             if (member.IsIdentity())
             {
-                Settings.ExtraSources.Add(invoker);
+                Settings.ExtraSources.Add((ExtraSourceModel)invoker);
                 return this;
             }
 
@@ -452,7 +452,7 @@ namespace Mapster
 
             if (destinationMember.IsIdentity())
             {
-                Settings.ExtraSources.Add(sourceMemberName);
+                Settings.ExtraSources.Add((ExtraSourceModel)sourceMemberName);
                 return this;
             }
 
@@ -648,7 +648,7 @@ namespace Mapster
             var invoker = Expression.Lambda(source.Body, Expression.Parameter(typeof(object)));
             if (member.IsIdentity())
             {
-                Settings.ExtraSources.Add(invoker);
+                Settings.ExtraSources.Add((ExtraSourceModel)invoker);
                 return this;
             }
 
@@ -710,7 +710,7 @@ namespace Mapster
             var sourceName = source.GetMemberPath(noError: true);
             if (member.IsIdentity())
             {
-                Settings.ExtraSources.Add((object?)sourceName ?? source);
+                Settings.ExtraSources.Add(new ExtraSourceModel((object?)sourceName ?? source));
                 return this;
             }
 

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -645,13 +645,7 @@ namespace Mapster
         {
             this.CheckCompiled();
 
-            var invoker = Expression.Lambda(source.Body, Expression.Parameter(typeof(object)));
-            if (member.IsIdentity())
-            {
-                Settings.ExtraSources.Add((ExtraSourceModel)invoker);
-                return this;
-            }
-
+            var invoker = Expression.Lambda(source.Body, Expression.Parameter(typeof(TSource)));
             TypeAdapterSettings? overrideSettings = null;
 
             if (configAction != null)
@@ -660,6 +654,12 @@ namespace Mapster
                 configAction(Tempsetter);
 
                 overrideSettings = Tempsetter.Settings;
+            }
+
+            if (member.IsIdentity())
+            {
+                Settings.ExtraSources.Add(new ExtraSourceModel(invoker, (OverrideTypesSettings?)overrideSettings));
+                return this;
             }
 
             Settings.Resolvers.Add(new InvokerModel

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -672,6 +672,45 @@ namespace Mapster
             return this;
         }
 
+        public TypeAdapterSetter<TSource, TDestination> ReMap<TDestinationMember, TSourceMember>(
+            Expression<Func<TDestination, TDestinationMember>> member,
+            Expression<Func<TSource, TSourceMember>> source,
+            bool SkipDestinationTransforms = false)
+        {
+            this.CheckCompiled();
+
+            
+
+            var invoker = Expression.Lambda(source.Body, Expression.Parameter(typeof(TSource)));
+            TypeAdapterSettings? overrideSettings = null;
+                        
+            var Tempsetter = new OverrideTypesSetter<TSourceMember, TDestinationMember>(this.Config);
+            overrideSettings = Tempsetter.Settings;
+                            
+
+            if (SkipDestinationTransforms)
+                Tempsetter.SkipDestinationTransforms();
+
+            if (member.IsIdentity())
+            {
+                Tempsetter._Settings.RemapExtraSource = true;
+
+                Settings.ExtraSources.Add(new ExtraSourceModel(invoker, (OverrideTypesSettings?)overrideSettings));
+                return this;
+            }
+
+            this.IgnoredRemove(member.GetMemberPath()!);
+
+            Settings.Resolvers.Add(new InvokerModel
+            {
+                DestinationMemberName = member.GetMemberPath()!,
+                Invoker = invoker,
+                Condition = null,
+                OvverideSettings = overrideSettings
+            });
+            return this;
+        }
+
 
 
         public TypeAdapterSetter<TSource, TDestination> IgnoreIf(

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -693,13 +693,13 @@ namespace Mapster
 
             if (member.IsIdentity())
             {
-                Tempsetter._Settings.RemapExtraSource = true;
+                Tempsetter._Settings.ReMapExtraSource = true;
 
                 Settings.ExtraSources.Add(new ExtraSourceModel(invoker, (OverrideTypesSettings?)overrideSettings));
                 return this;
             }
 
-            this.IgnoredRemove(member.GetMemberPath()!);
+            this.Settings.ReMapDestinationMembers.Add(member.GetMemberPath()!);
 
             Settings.Resolvers.Add(new InvokerModel
             {

--- a/src/Mapster/TypeAdapterSetters/OverrideTypesSetter.cs
+++ b/src/Mapster/TypeAdapterSetters/OverrideTypesSetter.cs
@@ -7,7 +7,7 @@ namespace Mapster
     [AdaptWith(AdaptDirectives.DestinationAsRecord)]
     public class OverrideTypesSetter : TypeAdapterSetter
     {
-        protected OverrideTypesSettings _Settings { get => (OverrideTypesSettings)Settings; }
+        internal protected OverrideTypesSettings _Settings { get => (OverrideTypesSettings)Settings; }
 
         public OverrideTypesSetter(TypeAdapterConfig config) : this (new OverrideTypesSettings (), config) { }
         public OverrideTypesSetter(TypeAdapterSettings settings, TypeAdapterConfig config) : base(settings, config) { }

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -134,9 +134,9 @@ namespace Mapster
         {
             get => Get(nameof(ShouldMapMember), () => new List<Func<IMemberModel, MemberSide, bool?>>());
         }
-        public List<Func<Expression, IMemberModel, CompileArgument, Expression?>> ValueAccessingStrategies
+        public List<Func<Expression, IMemberModel, CompileArgument, ResolverResult?>> ValueAccessingStrategies
         {
-            get => Get(nameof(ValueAccessingStrategies), () => new List<Func<Expression, IMemberModel, CompileArgument, Expression?>>());
+            get => Get(nameof(ValueAccessingStrategies), () => new List<Func<Expression, IMemberModel, CompileArgument, ResolverResult?>>());
         }
         public List<InvokerModel> Resolvers
         {

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -208,6 +208,11 @@ namespace Mapster
             set => Set(nameof(CustomDefaultValue), value);
         }
 
+        public List<string> ReMapDestinationMembers
+        {
+            get => Get(nameof(ReMapDestinationMembers), () => new List<string>());
+        }
+
         internal bool Compiled { get; set; }
 
         public TypeAdapterSettings Clone()

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -134,17 +134,17 @@ namespace Mapster
         {
             get => Get(nameof(ShouldMapMember), () => new List<Func<IMemberModel, MemberSide, bool?>>());
         }
-        public List<Func<Expression, IMemberModel, CompileArgument, ResolverResult?>> ValueAccessingStrategies
+        public List<Func<ResolverSourceInput, IMemberModel, CompileArgument, ResolverResult?>> ValueAccessingStrategies
         {
-            get => Get(nameof(ValueAccessingStrategies), () => new List<Func<Expression, IMemberModel, CompileArgument, ResolverResult?>>());
+            get => Get(nameof(ValueAccessingStrategies), () => new List<Func<ResolverSourceInput, IMemberModel, CompileArgument, ResolverResult?>>());
         }
         public List<InvokerModel> Resolvers
         {
             get => Get(nameof(Resolvers), () => new List<InvokerModel>());
         }
-        public List<object> ExtraSources
+        public List<ExtraSourceModel> ExtraSources
         {
-            get => Get(nameof(ExtraSources), () => new List<object>());
+            get => Get(nameof(ExtraSources), () => new List<ExtraSourceModel>());
         }
         public List<Func<CompileArgument, LambdaExpression>> BeforeMappingFactories
         {

--- a/src/Mapster/TypeAdapterSettings/OverrideTypesSettings.cs
+++ b/src/Mapster/TypeAdapterSettings/OverrideTypesSettings.cs
@@ -15,13 +15,13 @@ namespace Mapster
 
         public IEnumerable<string> ReMapDestination
         {
-            get => this.Resolvers.Select(x=>x.DestinationMemberName);
+            get => this.Resolvers.Select(x=>x.DestinationMemberName).Union(ReMapDestinationMembers);
         }
 
-        public bool? RemapExtraSource
+        public bool? ReMapExtraSource
         {
-            get => Get(nameof(RemapExtraSource));
-            set => Set(nameof(RemapExtraSource), value);
+            get => Get(nameof(ReMapExtraSource));
+            set => Set(nameof(ReMapExtraSource), value);
         }
 
         public bool? SkipAllSettings
@@ -63,7 +63,7 @@ namespace Mapster
 
             result.SkipAllSettings = this.SkipAllSettings;
             result.SkipSettings.AddRange(this.SkipSettings);
-            result.RemapExtraSource = this.RemapExtraSource;
+            result.ReMapExtraSource = this.ReMapExtraSource;
 
             return result;
         }

--- a/src/Mapster/TypeAdapterSettings/OverrideTypesSettings.cs
+++ b/src/Mapster/TypeAdapterSettings/OverrideTypesSettings.cs
@@ -1,4 +1,5 @@
 ﻿using Mapster.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -15,6 +16,12 @@ namespace Mapster
         public IEnumerable<string> ReMapDestination
         {
             get => this.Resolvers.Select(x=>x.DestinationMemberName);
+        }
+
+        public bool? RemapExtraSource
+        {
+            get => Get(nameof(RemapExtraSource));
+            set => Set(nameof(RemapExtraSource), value);
         }
 
         public bool? SkipAllSettings
@@ -47,6 +54,17 @@ namespace Mapster
                     result.Add(item);
                 }
             }
+            return result;
+        }
+
+        public OverrideTypesSettings CloneOnlySkipSettings()
+        {
+            var result = new OverrideTypesSettings();
+
+            result.SkipAllSettings = this.SkipAllSettings;
+            result.SkipSettings.AddRange(this.SkipSettings);
+            result.RemapExtraSource = this.RemapExtraSource;
+
             return result;
         }
     }

--- a/src/Mapster/TypeAdapterSettings/OverrideTypesSettings.cs
+++ b/src/Mapster/TypeAdapterSettings/OverrideTypesSettings.cs
@@ -12,6 +12,11 @@ namespace Mapster
             get => Get(nameof(SkipSettings), () => new List<string>());
         }
 
+        public IEnumerable<string> ReMapDestination
+        {
+            get => this.Resolvers.Select(x=>x.DestinationMemberName);
+        }
+
         public bool? SkipAllSettings
         {
             get => Get(nameof(SkipAllSettings));

--- a/src/Mapster/TypeAdapterSettings/OverrideTypesSettings.cs
+++ b/src/Mapster/TypeAdapterSettings/OverrideTypesSettings.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using Mapster.Models;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Mapster
 {
@@ -26,6 +28,21 @@ namespace Mapster
         {
             if(!SkipAllSettings.GetValueOrDefault())
                 base.ApplyWithSkipSettings(other, SkipSettings);
+        }
+
+        public List<InvokerModel> ApplyResolversOnly(TypeAdapterSettings other)
+        {
+            var result = new List<InvokerModel>(this.Resolvers);
+            var seen = new HashSet<InvokerModel>(result,new InvokerModelApplyComparer());
+
+            foreach (var item in other.Resolvers)
+            {
+                if (seen.Add(item))
+                {
+                    result.Add(item);
+                }
+            }
+            return result;
         }
     }
 }

--- a/src/Mapster/Utils/DirectParameterMemberFinder.cs
+++ b/src/Mapster/Utils/DirectParameterMemberFinder.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+
+public class DirectParameterMemberFinder : ExpressionVisitor
+{
+    private readonly bool _isCtrMapping;
+    private readonly HashSet<Expression> _TargetParams;
+    public List<Expression> FoundMembers { get; } = new();
+
+    public DirectParameterMemberFinder(bool conctructorMapping = false, params Expression[] targetParams)
+    {
+        _TargetParams = new HashSet<Expression>(targetParams);
+        _isCtrMapping = conctructorMapping;
+    }
+
+    protected override Expression VisitMember(MemberExpression node)
+    {
+        if (_TargetParams.Contains(GetParametr(node)))
+            if (_isCtrMapping)
+                FoundMembers.Add(node);
+            else
+                FoundMembers.Add(node.Expression);
+
+        return node;
+    }
+
+    protected override Expression VisitMethodCall(MethodCallExpression node)
+    {
+        if (node.Object is MemberExpression mem && _TargetParams.Contains(GetParametr(mem)))
+            FoundMembers.Add(mem);
+
+        foreach (var arg in node.Arguments)
+        {
+            if (arg is MemberExpression member && _TargetParams.Contains(GetParametr(member)))
+            {
+                // if Method is static for Type && not Extention method
+                if (node.Object == null && !node.Method.IsDefined(typeof(ExtensionAttribute), inherit: false))
+                    FoundMembers.Add(member.Expression);
+                else
+                    FoundMembers.Add(member);
+                continue;
+            }
+
+            if (arg.NodeType == ExpressionType.Call)
+            {
+                Visit(arg);
+            }
+        }
+
+        return node;
+    }
+
+    protected override Expression VisitUnary(UnaryExpression node)
+    {
+        if (node.NodeType == ExpressionType.Convert || node.NodeType == ExpressionType.ConvertChecked)
+        {
+            var result = base.VisitUnary(node);
+            return result;
+        }
+        return base.VisitUnary(node);
+    }
+       
+    public IEnumerable<Expression> Find(Expression expression)
+    {
+        FoundMembers.Clear();
+        Visit(expression);
+
+        return FoundMembers;
+    }
+      
+
+    private Expression GetParametr(MemberExpression member)
+    {
+        Expression current = member;
+
+        while (current != null)
+        {
+            if (current is MemberExpression mem)
+            {
+                current = mem.Expression;
+                continue;
+            }
+
+            if (current is ParameterExpression)
+                return current;
+            else
+                current = new ReturnParametrVisitor().GetParam(current);
+        }
+
+        return Expression.Empty();
+    }
+
+    internal class ReturnParametrVisitor : ExpressionVisitor
+    {
+        private Expression parametr;
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            parametr = node;
+            return node;
+        }
+
+        public Expression GetParam(Expression expression)
+        {
+            Visit(expression);
+            return parametr;
+        }
+    }
+
+
+}

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -452,9 +452,10 @@ namespace Mapster.Utils
 
             Expression? condition = null;
             var current = getter;
-            var checks = arg.Context.NullChecks
-                .Where(x => !object.ReferenceEquals(x.arg, arg))
-                .Select(x => x.param);
+            // ReadyToCleanUp
+            //var checks = arg.Context.NullChecks
+            //    .Where(x => !object.ReferenceEquals(x.arg, arg))
+            //    .Select(x => x.param);
 
             while (current != null) 
             {
@@ -462,8 +463,12 @@ namespace Mapster.Utils
 
                 if (current.CanBeNull() && current is not ParameterExpression)
                     compareNull = Expression.NotEqual(current, Expression.Constant(null, current.Type));
+                // ReadyToCleanUp
+                //else if (current.CanBeNull() && current is ParameterExpression param
+                //    && !checks.Contains(param))
                 else if (current.CanBeNull() && current is ParameterExpression param
-                    && !checks.Contains(param))
+                    && arg.MapType == MapType.Projection)
+
                     compareNull = Expression.NotEqual(param, Expression.Constant(null, param.Type));
 
                 if (compareNull != null)

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -152,6 +152,11 @@ namespace Mapster.Utils
             return lambda.Apply(mapType != MapType.Projection, exps);
         }
 
+        public static Expression ApplyExtraSources(this LambdaExpression lambda, MapType mapType, params Expression[] exps)
+        {
+            return lambda.ApplyExtraSources(mapType != MapType.Projection, exps);
+        }
+
         public static Expression Apply(this LambdaExpression lambda, ParameterExpression p1, ParameterExpression? p2 = null)
         {
             if (p2 == null)
@@ -163,6 +168,15 @@ namespace Mapster.Utils
         private static Expression Apply(this LambdaExpression lambda, bool allowInvoke, params Expression[] exps)
         {
             var replacer = new ParameterExpressionReplacer(lambda.Parameters, exps);
+            var result = replacer.Visit(lambda.Body);
+            if (!allowInvoke || !replacer.ReplaceCounts.Where((n, i) => n > 1 && exps[i].IsComplex()).Any())
+                return result!;
+            return Expression.Invoke(lambda, exps);
+        }
+
+        private static Expression ApplyExtraSources(this LambdaExpression lambda, bool allowInvoke, params Expression[] exps)
+        {
+            var replacer = new ParameterExpressionReplacer(lambda.Parameters,true, exps);
             var result = replacer.Visit(lambda.Body);
             if (!allowInvoke || !replacer.ReplaceCounts.Where((n, i) => n > 1 && exps[i].IsComplex()).Any())
                 return result!;

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -445,7 +445,7 @@ namespace Mapster.Utils
             return getter;
         }
 
-        public static Expression ApplyNullPropagationFromCtor(this Expression getter, Expression adapt, CompileArgument arg)
+        public static Expression ApplyNullPropagationFromCtor(this Expression getter, Expression adapt, CompileArgument arg, MemberMapping mapping)
         {
             if (getter == null)
                 return adapt;
@@ -488,7 +488,7 @@ namespace Mapster.Utils
             if (transform != null)
                 return transform.TransformFunc(adapt.Type).Apply(arg.MapType, Expression.Condition(condition, adapt, adapt.Type.CreateDefault(arg)));
 
-            return Expression.Condition(condition, adapt, adapt.Type.CreateDefault(arg));
+            return Expression.Condition(condition, adapt, adapt.Type.CreateDefault(member:mapping));
         }
 
         public static string? GetMemberPath(this LambdaExpression lambda, bool firstLevelOnly = false, bool noError = false)

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -438,10 +438,10 @@ namespace Mapster.Utils
                     if (!getter.CanBeNull())
                     {
                         var transform = Expression.Convert(getter, typeof(Nullable<>).MakeGenericType(getter.Type));
-                        return Expression.Condition(condition, transform, transform.Type.CreateDefault(arg));
+                        return Expression.Condition(condition, transform, transform.Type.CreateDefault());
                     }
                     else
-                        return Expression.Condition(condition, getter, getter.Type.CreateDefault(arg));
+                        return Expression.Condition(condition, getter, getter.Type.CreateDefault());
                 }
 
                 if (expr.CanBeNull())

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -486,9 +486,9 @@ namespace Mapster.Utils
             // add supporting DestinationTransforms
             var transform = arg.Settings.DestinationTransforms.Find(it => it.Condition(adapt.Type));
             if (transform != null)
-                return transform.TransformFunc(adapt.Type).Apply(arg.MapType, Expression.Condition(condition, adapt, Expression.Default(adapt.Type)));
+                return transform.TransformFunc(adapt.Type).Apply(arg.MapType, Expression.Condition(condition, adapt, adapt.Type.CreateDefault(arg)));
 
-            return Expression.Condition(condition, adapt, Expression.Default(adapt.Type));
+            return Expression.Condition(condition, adapt, adapt.Type.CreateDefault(arg));
         }
 
         public static string? GetMemberPath(this LambdaExpression lambda, bool firstLevelOnly = false, bool noError = false)

--- a/src/Mapster/Utils/ExpressionEx.cs
+++ b/src/Mapster/Utils/ExpressionEx.cs
@@ -421,7 +421,114 @@ namespace Mapster.Utils
 
             return param;
         }
-        public static Expression ApplyPropertyNullPropagation(this Expression getter, CompileArgument arg)
+
+        public static Expression ApplyPropertyNullPropagation(this Expression getter, CompileArgument arg, Expression source)
+        {
+            var current = getter;
+            var result = getter;
+            Expression? condition = null;
+
+            var finder = new DirectParameterMemberFinder(false,source);
+            var condition2 = finder.Find(getter)
+                .Select(x => x.GetNullPropagationChecks(arg))
+                .Where(x => x != null)
+                .ToArray().ConcatPropagationChecks();
+
+            if (condition2 == null)
+                return getter;
+
+            if (!getter.Type.CanBeNull())
+            {
+                var transform = Expression.Convert(getter, typeof(Nullable<>).MakeGenericType(getter.Type));
+                return Expression.Condition(condition2, transform, transform.Type.CreateDefault());
+            }
+            else
+                return Expression.Condition(condition2, getter, getter.Type.CreateDefault());
+        }  
+
+        public static Expression ApplyNullPropagationFromCtor(this Expression getter, Expression adapt, CompileArgument arg, MemberMapping mapping)
+        {
+            if (getter == null)
+                return adapt;
+
+            var finder = new DirectParameterMemberFinder(true,mapping.Source);
+
+            Expression? condition = finder.Find(getter)
+                .Select(x => x.GetNullPropagationChecks(arg))
+                .Where(x => x != null)
+                .ToArray().ConcatPropagationChecks();
+
+            if (condition == null)
+                return adapt;
+
+            // add supporting DestinationTransforms
+            var transform = arg.Settings.DestinationTransforms.Find(it => it.Condition(adapt.Type));
+            if (transform != null)
+                return transform.TransformFunc(adapt.Type).Apply(arg.MapType, Expression.Condition(condition, adapt, adapt.Type.CreateDefault(arg)));
+
+            return Expression.Condition(condition, adapt, adapt.Type.CreateDefault(member: mapping));
+        }
+
+
+        private static Expression? ConcatPropagationChecks(this Expression[] checks)
+        {
+            if (checks.Length == 0)
+                return null;
+
+            if (checks.Length == 1)
+                return checks.First();
+
+            Expression? result = null;
+
+            for (int i = 0; i < checks.Length; i++)
+            {
+                if (i == 0)
+                    result = checks[i];
+                else
+                {
+                    result = Expression.AndAlso(result, checks[i]);
+                }
+
+            }
+
+            return result;
+        }
+
+        private static Expression? GetNullPropagationChecks (this Expression getter, CompileArgument arg)
+        {
+            Expression? condition = null;
+            var current = getter;
+          
+            while (current != null)
+            {
+                Expression? compareNull = null;
+
+                if (current.Type.CanBeNull() && current is not ParameterExpression)
+                    compareNull = Expression.NotEqual(current, Expression.Constant(null, current.Type));
+             
+                else if (current.Type.CanBeNull() && current is ParameterExpression param
+                    && arg.MapType == MapType.Projection)
+
+                    compareNull = Expression.NotEqual(param, Expression.Constant(null, param.Type));
+
+                if (compareNull != null)
+                {
+                    if (condition == null)
+                        condition = compareNull;
+                    else
+                        condition = Expression.AndAlso(compareNull, condition);
+                }
+
+                if (current is MemberExpression member)
+                    current = member.Expression;
+                else
+                    current = null;
+            }
+
+            return condition;
+        }
+
+        public static Expression ApplyPropertyNullPropagationLegasy(this Expression getter, CompileArgument arg)
         {
             var current = getter;
             var result = getter;
@@ -429,7 +536,7 @@ namespace Mapster.Utils
 
             while (current.NodeType == ExpressionType.MemberAccess)
             {
-                var memEx = (MemberExpression) current;
+                var memEx = (MemberExpression)current;
                 var expr = memEx.Expression;
                 if (expr == null)
                     break;
@@ -459,7 +566,7 @@ namespace Mapster.Utils
             return getter;
         }
 
-        public static Expression ApplyNullPropagationFromCtor(this Expression getter, Expression adapt, CompileArgument arg, MemberMapping mapping)
+        public static Expression ApplyNullPropagationFromCtorLegasy(this Expression getter, Expression adapt, CompileArgument arg, MemberMapping mapping)
         {
             if (getter == null)
                 return adapt;

--- a/src/Mapster/Utils/ParameterExpressionReplacer.cs
+++ b/src/Mapster/Utils/ParameterExpressionReplacer.cs
@@ -8,10 +8,20 @@ namespace Mapster.Utils
         //fields
         readonly ReadOnlyCollection<ParameterExpression> _from;
         readonly Expression[] _to;
+        readonly bool _FromExtraSource;
 
         public int[] ReplaceCounts { get; }
 
         //constructors
+
+        public ParameterExpressionReplacer(ReadOnlyCollection<ParameterExpression> from,bool isExtraSource, params Expression[] to )
+        {
+            _from = from;
+            _to = to;
+            ReplaceCounts = new int[_to.Length];
+            _FromExtraSource = isExtraSource;
+        }
+
         public ParameterExpressionReplacer(ReadOnlyCollection<ParameterExpression> from, params Expression[] to)
         {
             _from = from;
@@ -24,7 +34,16 @@ namespace Mapster.Utils
             for (var i = 0; i < _from.Count; i++)
             {
                 if (node != _from[i])
-                    continue;
+                {
+                    if (_FromExtraSource)
+                    {
+                        if (node.Type != _from[i].Type)
+                            continue;
+                    }
+                    else
+                        continue;
+                }
+
                 if (i >= _to.Length)
                     return node.Type.CreateDefault();
 

--- a/src/Mapster/Utils/ParametrExpressionFinder.cs
+++ b/src/Mapster/Utils/ParametrExpressionFinder.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
+
+namespace Mapster.Utils
+{
+    sealed internal class ParametrExpressionFinder: ExpressionVisitor
+    {
+        private readonly List<ParameterExpression> _parameters = new();
+              
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            if (!_parameters.Contains(node))
+                _parameters.Add(node);
+
+            return base.VisitParameter(node);
+        }
+
+        public ReadOnlyCollection<ParameterExpression> Find(Expression expression)
+        {
+            _parameters.Clear();
+            this.Visit(expression);
+            return _parameters.AsReadOnly();
+        }
+    }
+
+    internal static class ReplaceOvverideExpressionParam
+    {
+        readonly static ParametrExpressionFinder ParamFinder = new ();
+
+        public static Expression Replace(Expression expression, params Expression[] to)
+        {
+           return new ParameterExpressionReplacer(ParamFinder.Find(expression), true, to).Visit(expression);
+        }
+    }
+}

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -358,10 +358,14 @@ namespace Mapster
             return type == typeof(object) || type.UnwrapNullable().IsConvertible();
         }
 
-        public static Expression CreateDefault(this Type type, CompileArgument? arg = null)
+        public static Expression CreateDefault(this Type type, CompileArgument? arg = null, MemberMapping? member = null)
         {
             if(arg !=null && arg.Settings.CustomDefaultValue != null)
                 return arg.Settings.CustomDefaultValue;
+
+            if (member != null && member.OverrideSettings != null
+                && member.OverrideSettings.CustomDefaultValue != null)
+                return member.OverrideSettings.CustomDefaultValue;
 
             return type.CanBeNull()
                 ? Expression.Constant(null, type)

--- a/src/Mapster/Utils/StringComparer.cs
+++ b/src/Mapster/Utils/StringComparer.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Mapster.Utils
+{
+    internal class MapsterStringComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string? x, string? y)
+        {
+            if(String.IsNullOrEmpty(x) || String.IsNullOrEmpty(y))
+                return false;
+
+           return String.Equals(x, y, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public int GetHashCode(string obj)
+        {
+            if(obj is null)
+                return 0;
+            
+            return obj.GetHashCode();
+        }
+    }
+}


### PR DESCRIPTION
Fix: 
 - added support `DefaultValue()` from constructor mapping;
 - added support `MapUsing()` from ExtraSource/Flattening mapping. 

Improvements:
- NullablePropagation improvements;
- added `ReMap()` setting setter - `Map()` for Ignored member  and an additional option to skip the application of Destination Transforms 

```
config.Default.AddDestinationTransform(DestinationTransform.EmptyCollectionIfNull);
            config.ForDestinationType<DestinationFlattentData>()
                .Ignore(x => x.Value);
            config.NewConfig<SourceFlattentInsaider, DestinationFlattentData>()
                .ReMap(dest => dest, src => src.SrcData, true); 

 var result = src.Adapt<DestinationFlattentData>(config);

            result.Collection.ShouldBeNull(); // all member from ExtraSource - SrcData  has skip DestinationTransform.EmptyCollectionIfNull 
            result.Value.ShouldBe("Hello"); // property Value has value from ExtraSource - SrcData
```