### PR TITLE
Fix #399 - Fix mapper interface generation for internal types

### DIFF
--- a/src/ExpressionTranslator/ExpressionTranslator.cs
+++ b/src/ExpressionTranslator/ExpressionTranslator.cs
@@ -56,6 +56,15 @@ namespace ExpressionDebugger
                 _indentLevel++;
         }
 
+        private bool IsGeneratedTypeInternal()
+        {
+            if (Definitions == null)
+                return false;
+
+            return Definitions.IsInternal ||
+                   Definitions.Implements?.Any(it => !it.GetTypeInfo().IsVisible) == true;
+        }
+
         public static ExpressionTranslator Create(Expression node, ExpressionDefinitions? definitions = null)
         {
             var translator = new ExpressionTranslator(definitions);
@@ -1201,7 +1210,7 @@ namespace ExpressionDebugger
                 if (type == LambdaType.PublicLambda)
                 {
                     var name = methodName ?? "Main";
-                    if (!isInternal)
+                    if (!isInternal && !IsGeneratedTypeInternal())
                         isInternal = node.ReturnType.GetTypeInfo().IsNotPublic ||
                                      node.Parameters.Any(it => it.Type.GetTypeInfo().IsNotPublic);
                     WriteModifierNextLine(isInternal ? "internal" : "public");
@@ -1235,7 +1244,7 @@ namespace ExpressionDebugger
                 var name = methodName ?? "Main";
                 if (type == LambdaType.PublicMethod || type == LambdaType.ExtensionMethod)
                 {
-                    if (!isInternal)
+                    if (!isInternal && !IsGeneratedTypeInternal())
                         isInternal = node.ReturnType.GetTypeInfo().IsNotPublic ||
                                      node.Parameters.Any(it => it.Type.GetTypeInfo().IsNotPublic);
                     WriteModifierNextLine(isInternal ? "internal" : "public");
@@ -1891,10 +1900,7 @@ namespace ExpressionDebugger
                         Indent();
                     }
 
-                    var isInternal = Definitions.IsInternal;
-                    if (!isInternal)
-                        isInternal = Definitions.Implements?.Any(it =>
-                            !it.GetTypeInfo().IsInterface && !it.GetTypeInfo().IsPublic) ?? false;
+                    var isInternal = IsGeneratedTypeInternal();
                     WriteModifierNextLine(isInternal ? "internal" : "public");
                     Write("partial ", Definitions.IsRecordType ? "record " : "class ", Definitions.TypeName);
                     if (Definitions.IsRecordType && ctorParams?.Count > 0)

--- a/src/Mapster.Tool.Tests/Mappers/IIssue399Mapper.cs
+++ b/src/Mapster.Tool.Tests/Mappers/IIssue399Mapper.cs
@@ -1,0 +1,10 @@
+using System.Linq.Expressions;
+
+namespace Mapster.Tool.Tests.Mappers;
+
+[Mapper]
+internal interface IIssue399Mapper
+{
+    Expression<Func<Issue399Source, Issue399Destination>> ProjectToDestination { get; }
+    Issue399Destination Map(Issue399Source source);
+}

--- a/src/Mapster.Tool.Tests/Mappers/Issue399Mapper.cs
+++ b/src/Mapster.Tool.Tests/Mappers/Issue399Mapper.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq.Expressions;
+using Mapster.Tool.Tests;
+using Mapster.Tool.Tests.Mappers;
+
+namespace Mapster.Tool.Tests.Mappers
+{
+    internal partial class Issue399Mapper : IIssue399Mapper
+    {
+        public Expression<Func<Issue399Source, Issue399Destination>> ProjectToDestination => p1 => new Issue399Destination()
+        {
+            Id = p1.Id,
+            Name = p1.Name
+        };
+        public Issue399Destination Map(Issue399Source p2)
+        {
+            return p2 == null ? null : new Issue399Destination()
+            {
+                Id = p2.Id,
+                Name = p2.Name
+            };
+        }
+    }
+}

--- a/src/Mapster.Tool.Tests/WhenMapperInterfaceUsesInternalTypes.cs
+++ b/src/Mapster.Tool.Tests/WhenMapperInterfaceUsesInternalTypes.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Mapster.Tool.Tests.Mappers;
+
+namespace Mapster.Tool.Tests;
+
+/// <summary>
+/// Tests for https://github.com/MapsterMapper/Mapster/issues/399
+/// </summary>
+public class WhenMapperInterfaceUsesInternalTypes : TestBase
+{
+    [Fact]
+    public void MapperInterfaceImplementationUsesInternalTypes()
+    {
+        IIssue399Mapper mapper = new Issue399Mapper();
+        var source = new Issue399Source { Id = 1, Name = "Test" };
+
+        var destination = mapper.Map(source);
+
+        destination.Id.Should().Be(source.Id);
+        destination.Name.Should().Be(source.Name);
+    }
+}
+
+internal class Issue399Source
+{
+    public int Id { get; init; }
+    public string? Name { get; init; }
+}
+
+internal class Issue399Destination
+{
+    public int Id { get; init; }
+    public string? Name { get; init; }
+}


### PR DESCRIPTION
Fixes mapper generation for interfaces that use internal source or destination types. The generated mapper class now uses the same effective visibility rule for both the class modifier and generated mapper members. If the generated class must be internal, its implicit interface implementation members can still be emitted as public.

Fixes #399.