### PR TITLE
Improvements for Mapster Tool

### DIFF
--- a/src/ExpressionTranslator/ExpressionTranslator.cs
+++ b/src/ExpressionTranslator/ExpressionTranslator.cs
@@ -1268,6 +1268,81 @@ namespace ExpressionDebugger
             }
         }
 
+        public Expression VisitLambdaForGenerateMappers(LambdaExpression node, LambdaType type, Type InterfaceType, string? methodName = null,
+           bool isInternal = false)
+        {
+            VisitLambda(node, type, methodName, isInternal);
+
+            if (type == LambdaType.PrivateLambda || type == LambdaType.PublicLambda)
+            {
+                _inlineCount++;
+                if (type == LambdaType.PublicLambda)
+                {
+                    var name = methodName != null ? $"{InterfaceType.FullName}.{methodName}" : "Main";
+                    WriteLine();
+                    var funcType = MakeDelegateType(node.ReturnType, node.Parameters.Select(it => it.Type).ToArray());
+                    var exprType = typeof(Expression<>).MakeGenericType(funcType);
+                    Write(Translate(exprType), " ", name, " => ");
+                }
+
+                IList<ParameterExpression> args;
+                if (node.Parameters.Count == 1)
+                {
+                    args = new List<ParameterExpression>();
+                    var arg = VisitParameter(node.Parameters[0]);
+                    args.Add((ParameterExpression)arg);
+                }
+                else
+                {
+                    args = VisitArguments("(", node.Parameters.ToList(), p => (ParameterExpression)VisitParameter(p),
+                        ")");
+                }
+
+                Write(" => ");
+                var body = VisitGroup(node.Body, ExpressionType.Quote);
+                if (type == LambdaType.PublicLambda)
+                    Write(";");
+                _inlineCount--;
+                return Expression.Lambda(body, node.Name, node.TailCall, args);
+            }
+            else
+            {
+                var name = methodName != null ? $"{InterfaceType.FullName}.{methodName}" : "Main";
+                if (type == LambdaType.PublicMethod || type == LambdaType.ExtensionMethod)
+                {
+                    if (!isInternal)
+                        isInternal = node.ReturnType.GetTypeInfo().IsNotPublic ||
+                                     node.Parameters.Any(it => it.Type.GetTypeInfo().IsNotPublic);
+                    WriteLine();
+                    Methods[name] = node.Type;
+                }
+                else
+                {
+                    name = GetName(node, name);
+                    WriteModifierNextLine("private");
+                }
+
+                Write(Translate(node.ReturnType), " ", name);
+                var open = "(";
+                if (type == LambdaType.ExtensionMethod)
+                {
+                    if (Definitions?.IsStatic != true)
+                        throw new InvalidOperationException("Extension method requires static class");
+                    if (node.Parameters.Count == 0)
+                        throw new InvalidOperationException("Extension method requires at least 1 parameter");
+                    open = "(this ";
+                }
+
+                var args = VisitArguments(open, node.Parameters, VisitParameterDeclaration, ")");
+                Indent();
+                var body = VisitBody(node.Body, true);
+
+                Outdent();
+
+                return Expression.Lambda(body, name, node.TailCall, args);
+            }
+        }
+
         private HashSet<LambdaExpression>? _visitedLambda;
         private int _writerLevel;
 

--- a/src/ExpressionTranslator/ExpressionTranslator.cs
+++ b/src/ExpressionTranslator/ExpressionTranslator.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Xml.Linq;
 
 namespace ExpressionDebugger
 {
@@ -1272,6 +1273,13 @@ namespace ExpressionDebugger
            bool isInternal = false)
         {
             VisitLambda(node, type, methodName, isInternal);
+
+            if (!isInternal)
+                isInternal = node.ReturnType.GetTypeInfo().IsNotPublic ||
+                             node.Parameters.Any(it => it.Type.GetTypeInfo().IsNotPublic);
+
+            if(!isInternal)
+                return node; // skip create interface implimentation if public only
 
             if (type == LambdaType.PrivateLambda || type == LambdaType.PublicLambda)
             {

--- a/src/ExpressionTranslator/ExpressionTranslator.cs
+++ b/src/ExpressionTranslator/ExpressionTranslator.cs
@@ -1940,8 +1940,15 @@ namespace ExpressionDebugger
                             WriteNextLine("using ", ns, ";");
                         }
 
-                        WriteLine();
                     }
+
+                    foreach (var ns in Definitions.GeneratedAttributes.Select(x => x.NameSpace).Distinct())
+                    {
+                        WriteNextLine("using ", ns, ";");
+                    }
+
+                    if(_usings != null || Definitions.GeneratedAttributes.Count != 0)
+                        WriteLine();
 
                     // NOTE: type alias cannot solve all name conflicted case, user should use PrintFullTypeName
                     // keep logic here for compatibility
@@ -1964,6 +1971,11 @@ namespace ExpressionDebugger
                     {
                         WriteNextLine("namespace ", Definitions.Namespace);
                         Indent();
+                    }
+
+                    foreach (var gAttr in Definitions.GeneratedAttributes)
+                    {
+                        WriteNextLine(gAttr.Implimentation);
                     }
 
                     var isInternal = Definitions.IsInternal;

--- a/src/ExpressionTranslator/Helpers/GeneratedAttributes/IGeneratedAttribute.cs
+++ b/src/ExpressionTranslator/Helpers/GeneratedAttributes/IGeneratedAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace ExpressionDebugger.Helpers.GeneratedAttributes
+{
+    public interface IGeneratedAttribute
+    {
+        public string NameSpace { get;}
+        public string Declaration { get;}
+        public string Implimentation { get; }
+        public string FileName { get;}
+
+    }
+}

--- a/src/ExpressionTranslator/Helpers/GeneratedAttributes/MapsterToolGeneratedMapperAttribute.cs
+++ b/src/ExpressionTranslator/Helpers/GeneratedAttributes/MapsterToolGeneratedMapperAttribute.cs
@@ -1,0 +1,14 @@
+﻿namespace ExpressionDebugger.Helpers.GeneratedAttributes
+{
+    public class MapsterToolGeneratedMapperAttribute : GeneratedBase, IGeneratedAttribute
+    {
+        public string NameSpace => "Mapster.Generated.Attributes";
+
+        public string Declaration =>
+            "using System;\r\n\r\nnamespace Mapster.Generated.Attributes\r\n{\r\n    public sealed class MapsterToolGeneratedMapperAttribute : Attribute\r\n    {\r\n\r\n    }\r\n} ";
+
+        public string Implimentation => "[MapsterToolGeneratedMapper]";
+
+        public string FileName => "MapsterToolGeneratedMapperAttribute";
+    }
+}

--- a/src/ExpressionTranslator/Helpers/GeneratedAttributes/MapsterToolGeneratedMapperAttribute.cs
+++ b/src/ExpressionTranslator/Helpers/GeneratedAttributes/MapsterToolGeneratedMapperAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using static ExpressionDebugger.Helpers.RandomNamespaceGenerator;
 
 namespace ExpressionDebugger.Helpers.GeneratedAttributes
 {
@@ -20,9 +21,12 @@ namespace ExpressionDebugger.Helpers.GeneratedAttributes
        {
             if (String.IsNullOrEmpty(extendedNameSpace))
                 throw new ArgumentNullException("Extended namespace not specified or is null/empty string");
-
-            _NameSpace = $"Mapster.Generated.Attributes.{extendedNameSpace}";
             
+            if(CheckNameSpace.IsMatch(extendedNameSpace))
+                _NameSpace = $"Mapster.Generated.Attributes.{extendedNameSpace}";
+            else
+                _NameSpace = $"Mapster.Generated.Attributes.{Generate(extendedNameSpace,1,1)}";
+
             _Declaration = new StringBuilder();
 
             _Declaration.Append("using System;\r\n\r\n");

--- a/src/ExpressionTranslator/Helpers/GeneratedAttributes/MapsterToolGeneratedMapperAttribute.cs
+++ b/src/ExpressionTranslator/Helpers/GeneratedAttributes/MapsterToolGeneratedMapperAttribute.cs
@@ -1,14 +1,36 @@
-﻿namespace ExpressionDebugger.Helpers.GeneratedAttributes
+﻿using System.Text;
+
+namespace ExpressionDebugger.Helpers.GeneratedAttributes
 {
     public class MapsterToolGeneratedMapperAttribute : GeneratedBase, IGeneratedAttribute
     {
-        public string NameSpace => "Mapster.Generated.Attributes";
+        private readonly StringBuilder _Declaration;
+        private readonly bool _isRandomNameSpace;
+        private readonly string _NameSpace;
 
-        public string Declaration =>
-            "using System;\r\n\r\nnamespace Mapster.Generated.Attributes\r\n{\r\n    public sealed class MapsterToolGeneratedMapperAttribute : Attribute\r\n    {\r\n\r\n    }\r\n} ";
+        public string NameSpace => _NameSpace;
+
+        public string Declaration => _Declaration.ToString();
 
         public string Implimentation => "[MapsterToolGeneratedMapper]";
 
         public string FileName => "MapsterToolGeneratedMapperAttribute";
+
+       public MapsterToolGeneratedMapperAttribute(bool isRandomNameSpace = false)
+       {
+            _isRandomNameSpace = isRandomNameSpace;
+
+            if (_isRandomNameSpace)
+                _NameSpace = $"Mapster.Generated.Attributes.{RandomNamespaceGenerator.Generate(1,1)}";
+            else
+                _NameSpace = "Mapster.Generated.Attributes";
+
+            _Declaration = new StringBuilder();
+
+            _Declaration.Append("using System;\r\n\r\n");
+            _Declaration.Append($"namespace {NameSpace}");
+            _Declaration.Append("\r\n{\r\n    public sealed class MapsterToolGeneratedMapperAttribute : Attribute\r\n    {\r\n\r\n    }\r\n} ");
+        }
+
     }
 }

--- a/src/ExpressionTranslator/Helpers/GeneratedAttributes/MapsterToolGeneratedMapperAttribute.cs
+++ b/src/ExpressionTranslator/Helpers/GeneratedAttributes/MapsterToolGeneratedMapperAttribute.cs
@@ -1,11 +1,11 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 
 namespace ExpressionDebugger.Helpers.GeneratedAttributes
 {
     public class MapsterToolGeneratedMapperAttribute : GeneratedBase, IGeneratedAttribute
     {
         private readonly StringBuilder _Declaration;
-        private readonly bool _isRandomNameSpace;
         private readonly string _NameSpace;
 
         public string NameSpace => _NameSpace;
@@ -16,15 +16,13 @@ namespace ExpressionDebugger.Helpers.GeneratedAttributes
 
         public string FileName => "MapsterToolGeneratedMapperAttribute";
 
-       public MapsterToolGeneratedMapperAttribute(bool isRandomNameSpace = false)
+       public MapsterToolGeneratedMapperAttribute(string extendedNameSpace)
        {
-            _isRandomNameSpace = isRandomNameSpace;
+            if (String.IsNullOrEmpty(extendedNameSpace))
+                throw new ArgumentNullException("Extended namespace not specified or is null/empty string");
 
-            if (_isRandomNameSpace)
-                _NameSpace = $"Mapster.Generated.Attributes.{RandomNamespaceGenerator.Generate(1,1)}";
-            else
-                _NameSpace = "Mapster.Generated.Attributes";
-
+            _NameSpace = $"Mapster.Generated.Attributes.{extendedNameSpace}";
+            
             _Declaration = new StringBuilder();
 
             _Declaration.Append("using System;\r\n\r\n");

--- a/src/ExpressionTranslator/Helpers/GeneratedBase.cs
+++ b/src/ExpressionTranslator/Helpers/GeneratedBase.cs
@@ -1,0 +1,18 @@
+﻿namespace ExpressionDebugger.Helpers
+{
+    public abstract class GeneratedBase 
+    {
+        public override bool Equals(object obj)
+        {
+            if(obj is null)
+                return base.Equals(obj);
+            else
+                return this.GetType() == obj.GetType();
+        }
+
+        public override int GetHashCode()
+        {
+            return this.GetType().GetHashCode();
+        }
+    }
+}

--- a/src/ExpressionTranslator/Helpers/MemberInfoExtensions.cs
+++ b/src/ExpressionTranslator/Helpers/MemberInfoExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Reflection;
+
+namespace ExpressionDebugger.Helpers
+{
+    public static class MemberInfoExtensions
+    {
+        public static bool IsPublicOrInternal(this MethodInfo method)
+        {
+            if (method == null) throw new ArgumentNullException(nameof(method));
+
+            return !method.IsPrivate
+                   && !method.IsFamily
+                   && !method.IsFamilyOrAssembly
+                   && !method.IsFamilyAndAssembly
+                   && (method.IsPublic || true);
+        }
+
+
+
+        public static bool IsGetterPublicOrInternal(this PropertyInfo property)
+        {
+            if (property == null) throw new ArgumentNullException(nameof(property));
+
+            MethodInfo? getMethod = property.GetMethod;
+
+            if (getMethod == null) return false;
+
+            return getMethod.IsPublicOrInternal();
+        }
+    }
+
+}

--- a/src/ExpressionTranslator/Helpers/RandomNamespaceGenerator.cs
+++ b/src/ExpressionTranslator/Helpers/RandomNamespaceGenerator.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Text;
+
+namespace ExpressionDebugger.Helpers
+{
+    public static class RandomNamespaceGenerator
+    {
+        private static readonly Random _random = new Random();
+        private const string Consonants = "bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ";
+        private const string Vowels = "aeiouAEIOU";
+        private const string Digits = "0123456789";
+
+        public static string Generate(int minParts = 2, int maxParts = 4)
+        {
+            if (minParts < 1) minParts = 1;
+            if (maxParts < minParts) maxParts = minParts;
+
+            int partsCount = _random.Next(minParts, maxParts + 1);
+            var sb = new StringBuilder();
+
+            for (int i = 0; i < partsCount; i++)
+            {
+                if (i > 0) sb.Append('.');
+                sb.Append(GeneratePart());
+            }
+
+            return sb.ToString();
+        }
+
+        private static string GeneratePart(int minLength = 2, int maxLength = 10)
+        {
+            if (minLength < 1) minLength = 1;
+            if (maxLength < minLength) maxLength = minLength;
+
+            int length = _random.Next(minLength, maxLength + 1);
+            var sb = new StringBuilder(length);
+
+            sb.Append(Consonants[_random.Next(Consonants.Length)]);
+
+            for (int i = 1; i < length; i++)
+            {
+                string pool = (i % 2 == 0) ? Vowels : Consonants;
+
+                if (_random.NextDouble() < 0.1)
+                {
+                    pool = Digits;
+                }
+
+                sb.Append(pool[_random.Next(pool.Length)]);
+            }
+
+            return sb.ToString();
+        }
+    }
+}
+

--- a/src/ExpressionTranslator/Helpers/RandomNamespaceGenerator.cs
+++ b/src/ExpressionTranslator/Helpers/RandomNamespaceGenerator.cs
@@ -1,19 +1,48 @@
 ﻿using System;
+using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace ExpressionDebugger.Helpers
 {
     public static class RandomNamespaceGenerator
     {
-        private static readonly Random _random = new Random();
+        public static readonly Regex CheckNameSpace = new Regex(@"^([a-zA-Z_]\w*)(\.[a-zA-Z_]\w*)*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private const string Consonants = "bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ";
         private const string Vowels = "aeiouAEIOU";
         private const string Digits = "0123456789";
+
+        public static string Generate(string input, int minParts = 2, int maxParts = 4)
+        {
+            if (string.IsNullOrEmpty(input)) throw new ArgumentException("Input cannot be empty.");
+            if (minParts < 1) minParts = 1;
+            if (maxParts < minParts) maxParts = minParts;
+
+            using var sha256 = SHA256.Create();
+            byte[] hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(input));
+
+            long seed = BitConverter.ToInt64(hashBytes, 0);
+            var random = new Random(unchecked((int)seed ^ (int)(seed >> 32)));
+
+            int partsCount = random.Next(minParts, maxParts + 1);
+            var sb = new StringBuilder();
+
+            for (int i = 0; i < partsCount; i++)
+            {
+                if (i > 0) sb.Append('.');
+                sb.Append(GeneratePart(random));
+            }
+
+            return sb.ToString();
+        }
+
 
         public static string Generate(int minParts = 2, int maxParts = 4)
         {
             if (minParts < 1) minParts = 1;
             if (maxParts < minParts) maxParts = minParts;
+            
+            var _random = new Random();
 
             int partsCount = _random.Next(minParts, maxParts + 1);
             var sb = new StringBuilder();
@@ -21,32 +50,27 @@ namespace ExpressionDebugger.Helpers
             for (int i = 0; i < partsCount; i++)
             {
                 if (i > 0) sb.Append('.');
-                sb.Append(GeneratePart());
+                sb.Append(GeneratePart(_random));
             }
 
             return sb.ToString();
         }
 
-        private static string GeneratePart(int minLength = 2, int maxLength = 10)
+        private static string GeneratePart(Random random, int minLength = 2, int maxLength = 10)
         {
             if (minLength < 1) minLength = 1;
             if (maxLength < minLength) maxLength = minLength;
 
-            int length = _random.Next(minLength, maxLength + 1);
+            int length = random.Next(minLength, maxLength + 1);
             var sb = new StringBuilder(length);
 
-            sb.Append(Consonants[_random.Next(Consonants.Length)]);
+            sb.Append(Consonants[random.Next(Consonants.Length)]);
 
             for (int i = 1; i < length; i++)
             {
                 string pool = (i % 2 == 0) ? Vowels : Consonants;
-
-                if (_random.NextDouble() < 0.1)
-                {
-                    pool = Digits;
-                }
-
-                sb.Append(pool[_random.Next(pool.Length)]);
+                if (random.NextDouble() < 0.1) pool = Digits;
+                sb.Append(pool[random.Next(pool.Length)]);
             }
 
             return sb.ToString();

--- a/src/ExpressionTranslator/TypeDefinitions.cs
+++ b/src/ExpressionTranslator/TypeDefinitions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ExpressionDebugger.Helpers.GeneratedAttributes;
+using System;
 using System.Collections.Generic;
 
 namespace ExpressionDebugger
@@ -12,6 +13,7 @@ namespace ExpressionDebugger
         public IEnumerable<Type>? Implements { get; set; }
         public bool PrintFullTypeName { get; set; }
         public bool IsRecordType { get; set; }
+        public HashSet<IGeneratedAttribute> GeneratedAttributes { get; set; } = new HashSet<IGeneratedAttribute>();
 
         /// <summary>
         /// Set to 2 to mark all properties as nullable

--- a/src/Mapster.Tool/MapperOptions.cs
+++ b/src/Mapster.Tool/MapperOptions.cs
@@ -28,6 +28,9 @@ namespace Mapster.Tool
         [Option('N', "nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated mapper files")]
         public bool GenerateNullableDirective { get; set; }
 
+        [Option('H', "createHelpers", Required = false, HelpText = "Set true to create helper files")]
+        public bool CreateHelpers { get; set; }
+
         [Usage(ApplicationAlias = "dotnet mapster mapper")]
         public static IEnumerable<Example> Examples =>
             new List<Example>

--- a/src/Mapster.Tool/MapperOptions.cs
+++ b/src/Mapster.Tool/MapperOptions.cs
@@ -28,8 +28,12 @@ namespace Mapster.Tool
         [Option('N', "nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated mapper files")]
         public bool GenerateNullableDirective { get; set; }
 
-        [Option('H', "extNamespace", Required = false, HelpText = "Specify namespace to activate and generate additional features")]
-        public string? CreateHelpers { get; set; }
+        [Option('h', "helpersCreate", Required = false, HelpText = "Generate helpers features")]
+        public bool CreateHelpers { get; set; }
+
+        [Option('H', "helpersNamespace", Required = false, HelpText = "Specify additional namespace to generated helpers features")]
+        public string? HelpersNamespace { get; set; }
+               
 
         [Usage(ApplicationAlias = "dotnet mapster mapper")]
         public static IEnumerable<Example> Examples =>

--- a/src/Mapster.Tool/MapperOptions.cs
+++ b/src/Mapster.Tool/MapperOptions.cs
@@ -28,8 +28,8 @@ namespace Mapster.Tool
         [Option('N', "nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated mapper files")]
         public bool GenerateNullableDirective { get; set; }
 
-        [Option('H', "createHelpers", Required = false, HelpText = "Set true to create helper files")]
-        public bool CreateHelpers { get; set; }
+        [Option('H', "extNamespace", Required = false, HelpText = "Specify namespace to activate and generate additional features")]
+        public string? CreateHelpers { get; set; }
 
         [Usage(ApplicationAlias = "dotnet mapster mapper")]
         public static IEnumerable<Example> Examples =>

--- a/src/Mapster.Tool/Program.cs
+++ b/src/Mapster.Tool/Program.cs
@@ -93,7 +93,11 @@ namespace Mapster.Tool
             config.SelfContainedCodeGeneration = true;
             config.Scan(assembly);
 
-            var generatedAtrr = new[] { new MapsterToolGeneratedMapperAttribute() };
+            var generatedAtrr = new List<IGeneratedAttribute>();
+
+            if (!String.IsNullOrEmpty(opt.CreateHelpers))
+                generatedAtrr.Add(new MapsterToolGeneratedMapperAttribute(opt.CreateHelpers));
+            
 
             foreach (var type in assembly.GetLoadableTypes())
             {
@@ -113,11 +117,8 @@ namespace Mapster.Tool
                     TypeName = attr.Name ?? GetImplName(GetCodeFriendlyTypeName(type)),
                     IsInternal = attr.IsInternal,
                     PrintFullTypeName = opt.PrintFullTypeName,
-                    
+                    GeneratedAttributes = new(generatedAtrr)
                 };
-
-                if (opt.CreateHelpers)
-                    definitions.GeneratedAttributes = new(generatedAtrr);
 
                 bool? _isForceInternal = definitions.IsInternal ? true : null;
 
@@ -194,12 +195,10 @@ namespace Mapster.Tool
                 WriteFile(code, path);
             }
 
-            if (opt.CreateHelpers)
+            
+            foreach (var item in generatedAtrr)
             {
-                foreach (var item in generatedAtrr)
-                {
-                    WriteFile(item.Declaration, GetOutput(opt.Output, null, item.FileName));
-                }
+                WriteFile(item.Declaration, GetOutput(opt.Output, null, item.FileName));
             }
         }
 

--- a/src/Mapster.Tool/Program.cs
+++ b/src/Mapster.Tool/Program.cs
@@ -138,9 +138,10 @@ namespace Mapster.Tool
                         var funcArgs = propArgs.GetGenericArguments();
                         var tuple = new TypeTuple(funcArgs[0], funcArgs[1]);
                         var expr = config.CreateMapExpression(tuple, MapType.Projection);
-                        translator.VisitLambda(
+                        translator.VisitLambdaForGenerateMappers(
                             expr,
                             ExpressionTranslator.LambdaType.PublicLambda,
+                            @interface,
                             prop.Name
                         );
                     }
@@ -162,9 +163,10 @@ namespace Mapster.Tool
                             tuple,
                             methodArgs.Length == 1 ? MapType.Map : MapType.MapToTarget
                         );
-                        translator.VisitLambda(
+                        translator.VisitLambdaForGenerateMappers(
                             expr,
                             ExpressionTranslator.LambdaType.PublicMethod,
+                            @interface,
                             method.Name
                         );
                     }

--- a/src/Mapster.Tool/Program.cs
+++ b/src/Mapster.Tool/Program.cs
@@ -1,5 +1,6 @@
 ﻿using CommandLine;
 using ExpressionDebugger;
+using ExpressionDebugger.Helpers;
 using ExpressionDebugger.Helpers.GeneratedAttributes;
 using Mapster.Models;
 using Mapster.Utils;
@@ -118,6 +119,8 @@ namespace Mapster.Tool
                 if (opt.CreateHelpers)
                     definitions.GeneratedAttributes = new(generatedAtrr);
 
+                bool? _isForceInternal = definitions.IsInternal ? true : null;
+
                 var path = GetOutput(opt.Output, segments, definitions.TypeName);
                 if (opt.SkipExistingFiles && File.Exists(path))
                 {
@@ -131,7 +134,9 @@ namespace Mapster.Tool
                 var interfaces = type.GetAllInterfaces();
                 foreach (var @interface in interfaces)
                 {
-                    foreach (var prop in @interface.GetProperties())
+                    foreach (var prop in @interface.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                                .Where(x => x.IsGetterPublicOrInternal())
+                            )
                     {
                         if (!prop.PropertyType.IsGenericType)
                             continue;
@@ -149,14 +154,17 @@ namespace Mapster.Tool
                             expr,
                             ExpressionTranslator.LambdaType.PublicLambda,
                             @interface,
-                            prop.Name
+                            prop.Name,
+                            _isForceInternal ?? (!prop.GetMethod?.IsPublic ?? false)
                         );
                     }
                 }
 
                 foreach (var @interface in interfaces)
                 {
-                    foreach (var method in @interface.GetMethods())
+                    foreach (var method in @interface.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                                .Where(x => x.IsPublicOrInternal())
+                            )
                     {
                         if (method.IsGenericMethod)
                             continue;
@@ -174,7 +182,8 @@ namespace Mapster.Tool
                             expr,
                             ExpressionTranslator.LambdaType.PublicMethod,
                             @interface,
-                            method.Name
+                            method.Name,
+                            _isForceInternal ?? !method.IsPublic
                         );
                     }
                 }

--- a/src/Mapster.Tool/Program.cs
+++ b/src/Mapster.Tool/Program.cs
@@ -95,8 +95,10 @@ namespace Mapster.Tool
 
             var generatedAtrr = new List<IGeneratedAttribute>();
 
-            if (!String.IsNullOrEmpty(opt.CreateHelpers))
-                generatedAtrr.Add(new MapsterToolGeneratedMapperAttribute(opt.CreateHelpers));
+            if (opt.CreateHelpers)
+                generatedAtrr.Add(new MapsterToolGeneratedMapperAttribute(
+                    opt.HelpersNamespace ?? Path.GetFileNameWithoutExtension(opt.Assembly)
+                    ));
             
 
             foreach (var type in assembly.GetLoadableTypes())

--- a/src/Mapster.Tool/Program.cs
+++ b/src/Mapster.Tool/Program.cs
@@ -112,8 +112,11 @@ namespace Mapster.Tool
                     TypeName = attr.Name ?? GetImplName(GetCodeFriendlyTypeName(type)),
                     IsInternal = attr.IsInternal,
                     PrintFullTypeName = opt.PrintFullTypeName,
-                    GeneratedAttributes = new(generatedAtrr)
+                    
                 };
+
+                if (opt.CreateHelpers)
+                    definitions.GeneratedAttributes = new(generatedAtrr);
 
                 var path = GetOutput(opt.Output, segments, definitions.TypeName);
                 if (opt.SkipExistingFiles && File.Exists(path))
@@ -182,9 +185,12 @@ namespace Mapster.Tool
                 WriteFile(code, path);
             }
 
-            foreach (var item in generatedAtrr)
+            if (opt.CreateHelpers)
             {
-                WriteFile(item.Declaration, GetOutput(opt.Output, null, item.FileName));
+                foreach (var item in generatedAtrr)
+                {
+                    WriteFile(item.Declaration, GetOutput(opt.Output, null, item.FileName));
+                }
             }
         }
 

--- a/src/Mapster.Tool/Program.cs
+++ b/src/Mapster.Tool/Program.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿using CommandLine;
+using ExpressionDebugger;
+using ExpressionDebugger.Helpers.GeneratedAttributes;
+using Mapster.Models;
+using Mapster.Utils;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,10 +11,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Text;
-using CommandLine;
-using ExpressionDebugger;
-using Mapster.Models;
-using Mapster.Utils;
 
 namespace Mapster.Tool
 {
@@ -91,6 +92,8 @@ namespace Mapster.Tool
             config.SelfContainedCodeGeneration = true;
             config.Scan(assembly);
 
+            var generatedAtrr = new[] { new MapsterToolGeneratedMapperAttribute() };
+
             foreach (var type in assembly.GetLoadableTypes())
             {
                 if (!type.IsInterface)
@@ -109,6 +112,7 @@ namespace Mapster.Tool
                     TypeName = attr.Name ?? GetImplName(GetCodeFriendlyTypeName(type)),
                     IsInternal = attr.IsInternal,
                     PrintFullTypeName = opt.PrintFullTypeName,
+                    GeneratedAttributes = new(generatedAtrr)
                 };
 
                 var path = GetOutput(opt.Output, segments, definitions.TypeName);
@@ -176,6 +180,11 @@ namespace Mapster.Tool
                     ? $"#nullable enable{Environment.NewLine}{translator}"
                     : translator.ToString();
                 WriteFile(code, path);
+            }
+
+            foreach (var item in generatedAtrr)
+            {
+                WriteFile(item.Declaration, GetOutput(opt.Output, null, item.FileName));
             }
         }
 

--- a/src/TemplateTest/CreateMapExpressionTest.cs
+++ b/src/TemplateTest/CreateMapExpressionTest.cs
@@ -1,7 +1,11 @@
 using ExpressionDebugger;
+using ExpressionDebugger.Helpers.GeneratedAttributes;
 using Mapster;
+using Mapster.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace TemplateTest
 {
@@ -64,6 +68,86 @@ namespace TemplateTest
 
             Assert.IsNotNull(code);
         }
+
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/399
+        /// </summary>
+        [TestMethod]
+        public void TestRegressionMapperGenerationTranslation()
+        {
+            var config = new TypeAdapterConfig();
+            config.SelfContainedCodeGeneration = true;
+           
+            var definitions = new TypeDefinitions
+            {
+                Implements = new[] { typeof(IMyTypeMapper) },
+                Namespace = "Benchmark",
+                TypeName = "CustomerMapper",
+                IsInternal = true,
+                GeneratedAttributes = new(new[] {new MapsterToolGeneratedMapperAttribute()})
+            };
+
+            var translator = new ExpressionTranslator(definitions);
+
+            foreach (var method in typeof(IMyTypeMapper).GetMethods())
+            {
+                if (method.IsGenericMethod)
+                    continue;
+                if (method.ReturnType == typeof(void))
+                    continue;
+                var methodArgs = method.GetParameters();
+                if (methodArgs.Length < 1 || methodArgs.Length > 2)
+                    continue;
+                var tuple = new TypeTuple(methodArgs[0].ParameterType, method.ReturnType);
+                var expr = config.CreateMapExpression(
+                    tuple,
+                    methodArgs.Length == 1 ? MapType.Map : MapType.MapToTarget
+                );
+                translator.VisitLambdaForGenerateMappers(
+                    expr,
+                    ExpressionTranslator.LambdaType.PublicMethod,
+                    typeof(IMyTypeMapper),
+                    method.Name
+                );
+            }
+
+            foreach (var prop in typeof(IMyTypeMapper).GetProperties())
+            {
+                if (!prop.PropertyType.IsGenericType)
+                    continue;
+                if (prop.PropertyType.GetGenericTypeDefinition() != typeof(Expression<>))
+                    continue;
+                var propArgs = prop.PropertyType.GetGenericArguments()[0];
+                if (!propArgs.IsGenericType)
+                    continue;
+                if (propArgs.GetGenericTypeDefinition() != typeof(Func<,>))
+                    continue;
+                var funcArgs = propArgs.GetGenericArguments();
+                var tuple = new TypeTuple(funcArgs[0], funcArgs[1]);
+                var expr = config.CreateMapExpression(tuple, MapType.Projection);
+                translator.VisitLambdaForGenerateMappers(
+                    expr,
+                    ExpressionTranslator.LambdaType.PublicLambda,
+                    typeof(IMyTypeMapper),
+                    prop.Name
+                );
+            }
+                      
+
+            var txt = translator.ToString();
+
+            Assert.IsTrue(txt.Contains("Expression<Func<AddressDTO, Address>> TemplateTest.IMyTypeMapper.Projection"));
+            Assert.IsTrue(txt.Contains("AddressDTO TemplateTest.IMyTypeMapper.Map"));
+            Assert.IsTrue(txt.Contains("[MapsterToolGeneratedMapper]"));
+
+        }
+
+    }
+
+    internal interface IMyTypeMapper
+    {
+        AddressDTO Map(Address p1);
+        Expression<Func<AddressDTO, Address>> Projection { get; }
     }
 
     public class Address

--- a/src/TemplateTest/CreateMapExpressionTest.cs
+++ b/src/TemplateTest/CreateMapExpressionTest.cs
@@ -1,11 +1,14 @@
 using ExpressionDebugger;
+using ExpressionDebugger.Helpers;
 using ExpressionDebugger.Helpers.GeneratedAttributes;
 using Mapster;
 using Mapster.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace TemplateTest
 {
@@ -82,74 +85,95 @@ namespace TemplateTest
            
             var definitions = new TypeDefinitions
             {
-                Implements = new[] { typeof(IMyTypeMapper) },
+                Implements = new[] { typeof(IMyTypeMapper), typeof(IMyTypeMapperIntenal) },
                 Namespace = "Benchmark",
                 TypeName = "CustomerMapper",
-                IsInternal = true,
+                IsInternal = false, 
                 GeneratedAttributes = new(new[] {new MapsterToolGeneratedMapperAttribute()})
             };
 
             var translator = new ExpressionTranslator(definitions);
 
-            foreach (var method in typeof(IMyTypeMapper).GetMethods())
-            {
-                if (method.IsGenericMethod)
-                    continue;
-                if (method.ReturnType == typeof(void))
-                    continue;
-                var methodArgs = method.GetParameters();
-                if (methodArgs.Length < 1 || methodArgs.Length > 2)
-                    continue;
-                var tuple = new TypeTuple(methodArgs[0].ParameterType, method.ReturnType);
-                var expr = config.CreateMapExpression(
-                    tuple,
-                    methodArgs.Length == 1 ? MapType.Map : MapType.MapToTarget
-                );
-                translator.VisitLambdaForGenerateMappers(
-                    expr,
-                    ExpressionTranslator.LambdaType.PublicMethod,
-                    typeof(IMyTypeMapper),
-                    method.Name
-                );
-            }
+            translator.CreateFromInterface(definitions, config);
 
-            foreach (var prop in typeof(IMyTypeMapper).GetProperties())
-            {
-                if (!prop.PropertyType.IsGenericType)
-                    continue;
-                if (prop.PropertyType.GetGenericTypeDefinition() != typeof(Expression<>))
-                    continue;
-                var propArgs = prop.PropertyType.GetGenericArguments()[0];
-                if (!propArgs.IsGenericType)
-                    continue;
-                if (propArgs.GetGenericTypeDefinition() != typeof(Func<,>))
-                    continue;
-                var funcArgs = propArgs.GetGenericArguments();
-                var tuple = new TypeTuple(funcArgs[0], funcArgs[1]);
-                var expr = config.CreateMapExpression(tuple, MapType.Projection);
-                translator.VisitLambdaForGenerateMappers(
-                    expr,
-                    ExpressionTranslator.LambdaType.PublicLambda,
-                    typeof(IMyTypeMapper),
-                    prop.Name
-                );
-            }
-                      
+            var code = translator.ToString();
 
-            var txt = translator.ToString();
+            Assert.IsTrue(code.Contains("public partial class CustomerMapper")); // mapper class is public
 
-            Assert.IsTrue(txt.Contains("Expression<Func<AddressDTO, Address>> TemplateTest.IMyTypeMapper.Projection"));
-            Assert.IsTrue(txt.Contains("AddressDTO TemplateTest.IMyTypeMapper.Map"));
-            Assert.IsTrue(txt.Contains("[MapsterToolGeneratedMapper]"));
+            Assert.IsTrue(code.Contains("Expression<Func<AddressDTO, Address>> TemplateTest.IMyTypeMapper.Projection"));
+            Assert.IsTrue(code.Contains("AddressDTO TemplateTest.IMyTypeMapper.Map"));
+            Assert.IsTrue(code.Contains("[MapsterToolGeneratedMapper]"));
 
+            Assert.IsTrue(code.Contains("internal AddressDTO Map")); // create internal method in public interface
+
+            // create as internal because declarate in internal interface and using internal type AddressInternal
+            Assert.IsTrue(code.Contains("internal AddressInternal MapInternal"));
+            Assert.IsTrue(code.Contains("internal Expression<Func<AddressInternal, Address>> ProjectionInternal"));
+
+            
+            Assert.IsTrue(code.Contains("public AddressDTO MapPublicClassInInternalInterface")); // create public method in internal interface because using public types
+
+            // method using public types in internal interface but marked as internal create as internal method
+            Assert.IsTrue(code.Contains("internal AddressDTO MapPublicClassInInternalInterfaceWithMarkInternal"));
         }
+
+        [TestMethod]
+        public void CreateForceInternalMapper()
+        {
+            var config = new TypeAdapterConfig();
+            config.SelfContainedCodeGeneration = true;
+
+            var definitions = new TypeDefinitions
+            {
+                Implements = new[] { typeof(IMyTypeMapperForce)},
+                Namespace = "Benchmark",
+                TypeName = "CustomerMapper",
+                IsInternal = true, // force create internal mapper
+                GeneratedAttributes = new(new[] { new MapsterToolGeneratedMapperAttribute() })
+            };
+
+            var translator = new ExpressionTranslator(definitions);
+
+            translator.CreateFromInterface(definitions, config);
+
+            var code = translator.ToString();
+
+            Assert.IsTrue(code.Contains("internal partial class CustomerMapper")); // mapper class is internal
+
+            // force create internal method using only public types because mapper class is internal
+            Assert.IsTrue(code.Contains("internal AddressDTO Map")); 
+        }
+
+
 
     }
 
-    internal interface IMyTypeMapper
+   
+    public interface IMyTypeMapper
+    {
+       internal AddressDTO Map(Address p1);
+       public Expression<Func<AddressDTO, Address>> Projection { get; }
+    }
+
+    internal interface IMyTypeMapperIntenal
+    {
+        AddressInternal MapInternal(Address p1);
+        Expression<Func<AddressInternal, Address>> ProjectionInternal { get; }
+        AddressDTO MapPublicClassInInternalInterface(Address p1);
+        internal AddressDTO MapPublicClassInInternalInterfaceWithMarkInternal(Address p1);
+    }
+
+    public interface IMyTypeMapperForce
     {
         AddressDTO Map(Address p1);
-        Expression<Func<AddressDTO, Address>> Projection { get; }
+    }
+
+    internal class AddressInternal
+    {
+        public int Id { get; set; }
+        public string Street { get; set; }
+        public string City { get; set; }
+        public string Country { get; set; }
     }
 
     public class Address
@@ -187,5 +211,69 @@ namespace TemplateTest
         public AddressDTO[] Addresses { get; set; }
         public List<AddressDTO> WorkAddresses { get; set; }
         public string AddressCity { get; set; }
+    }
+
+    static class GenerateMappersExtensions
+    {
+        public static void CreateFromInterface(this ExpressionTranslator translator, TypeDefinitions definitions, TypeAdapterConfig config)
+        {
+            if (definitions.Implements == null)
+                return;
+
+            foreach (var interfaceType in definitions.Implements)
+            {
+                bool? _isForceInternal = definitions.IsInternal ? true : null;
+
+                foreach (var method in interfaceType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                        .Where(x => x.IsPublicOrInternal())
+                    )
+                {
+                    if (method.IsGenericMethod)
+                        continue;
+                    if (method.ReturnType == typeof(void))
+                        continue;
+                    var methodArgs = method.GetParameters();
+                    if (methodArgs.Length < 1 || methodArgs.Length > 2)
+                        continue;
+                    var tuple = new TypeTuple(methodArgs[0].ParameterType, method.ReturnType);
+                    var expr = config.CreateMapExpression(
+                        tuple,
+                        methodArgs.Length == 1 ? MapType.Map : MapType.MapToTarget
+                    );
+                    translator.VisitLambdaForGenerateMappers(
+                        expr,
+                        ExpressionTranslator.LambdaType.PublicMethod,
+                        interfaceType,
+                        method.Name,
+                       _isForceInternal ?? !method.IsPublic
+                    );
+                }
+
+                foreach (var prop in interfaceType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                            .Where(x => x.IsGetterPublicOrInternal())
+                        )
+                {
+                    if (!prop.PropertyType.IsGenericType)
+                        continue;
+                    if (prop.PropertyType.GetGenericTypeDefinition() != typeof(Expression<>))
+                        continue;
+                    var propArgs = prop.PropertyType.GetGenericArguments()[0];
+                    if (!propArgs.IsGenericType)
+                        continue;
+                    if (propArgs.GetGenericTypeDefinition() != typeof(Func<,>))
+                        continue;
+                    var funcArgs = propArgs.GetGenericArguments();
+                    var tuple = new TypeTuple(funcArgs[0], funcArgs[1]);
+                    var expr = config.CreateMapExpression(tuple, MapType.Projection);
+                    translator.VisitLambdaForGenerateMappers(
+                        expr,
+                        ExpressionTranslator.LambdaType.PublicLambda,
+                        interfaceType,
+                        prop.Name,
+                        _isForceInternal ?? (!prop.GetMethod?.IsPublic ?? false)
+                    );
+                }
+            }
+        }    
     }
 }

--- a/src/TemplateTest/CreateMapExpressionTest.cs
+++ b/src/TemplateTest/CreateMapExpressionTest.cs
@@ -75,6 +75,8 @@ namespace TemplateTest
         [TestMethod]
         public void TestRegressionMapperGenerationTranslation()
         {
+            var S = new MapsterToolGeneratedMapperAttribute(true);
+
             var config = new TypeAdapterConfig();
             config.SelfContainedCodeGeneration = true;
            

--- a/src/TemplateTest/CreateMapExpressionTest.cs
+++ b/src/TemplateTest/CreateMapExpressionTest.cs
@@ -78,7 +78,7 @@ namespace TemplateTest
         [TestMethod]
         public void TestRegressionMapperGenerationTranslation()
         {
-            var S = new MapsterToolGeneratedMapperAttribute(true);
+            var S = new MapsterToolGeneratedMapperAttribute("Test");
 
             var config = new TypeAdapterConfig();
             config.SelfContainedCodeGeneration = true;
@@ -89,7 +89,7 @@ namespace TemplateTest
                 Namespace = "Benchmark",
                 TypeName = "CustomerMapper",
                 IsInternal = false, 
-                GeneratedAttributes = new(new[] {new MapsterToolGeneratedMapperAttribute()})
+                GeneratedAttributes = new(new[] {new MapsterToolGeneratedMapperAttribute("Test") })
             };
 
             var translator = new ExpressionTranslator(definitions);
@@ -129,7 +129,7 @@ namespace TemplateTest
                 Namespace = "Benchmark",
                 TypeName = "CustomerMapper",
                 IsInternal = true, // force create internal mapper
-                GeneratedAttributes = new(new[] { new MapsterToolGeneratedMapperAttribute() })
+                GeneratedAttributes = new(new[] { new MapsterToolGeneratedMapperAttribute("Test") })
             };
 
             var translator = new ExpressionTranslator(definitions);

--- a/src/TemplateTest/CreateMapExpressionTest.cs
+++ b/src/TemplateTest/CreateMapExpressionTest.cs
@@ -99,8 +99,6 @@ namespace TemplateTest
             var code = translator.ToString();
 
             Assert.IsTrue(code.Contains("public partial class CustomerMapper")); // mapper class is public
-
-            Assert.IsTrue(code.Contains("Expression<Func<AddressDTO, Address>> TemplateTest.IMyTypeMapper.Projection"));
             Assert.IsTrue(code.Contains("AddressDTO TemplateTest.IMyTypeMapper.Map"));
             Assert.IsTrue(code.Contains("[MapsterToolGeneratedMapper]"));
 


### PR DESCRIPTION
Improvements for [generating mappers from interface](https://mapstermapper.github.io/Mapster/articles/tools/mapster-tool/Interface-base-Code-generation.html#generate-mapper-from-interface) :
1. Added support mappers that use internal methods or properties.
2. Added support for marking generated mapper attributes `[MapsterToolGeneratedMapper]`
	new Mapster.Tool command `mapper` option:
	- -h: true - Create a mapper with helpers attributes
	- -H: - add additional namespace for generated helpers attributes

> [!NOTE]
> By default helpers attributes generate in namespace `Mapster.Generated.Attributes.{Filename of assembly} ` specified in the `-a` option.
`-H: "MyNameSpace"` - create next namespace `Mapster.Generated.Attributes.MyNameSpace `
>If assembly filename or the string passed as a parameter ` -H` is not a valid C# namespace, a additional namespace will be created automatically.